### PR TITLE
cater for array of doubles when decoding LatLong from Object

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/geo/GeoUtil.java
+++ b/src/main/java/com/github/fakemongo/impl/geo/GeoUtil.java
@@ -151,6 +151,11 @@ public final class GeoUtil {
         if (dbObject.containsField("lng") && dbObject.containsField("lat")) {
           latLong = new LatLong(((Number) dbObject.get("lat")).doubleValue(), ((Number) dbObject.get("lng")).doubleValue());
         }
+      } else if (value instanceof double[]) {
+    	  double[] array = (double[]) value;
+    	  if (array.length == 2) {
+    		  latLong = new LatLong(((Number) array[1]).doubleValue(), ((Number) array[0]).doubleValue()); 
+    	  }
       }
       if (latLong != null) {
         result.add(latLong);


### PR DESCRIPTION
An example using spring data of a double array that isn't catered for by Fongo

`@GeoSpatialIndexed`
    `private double[] random = new double[]{RandomUtils.nextDouble(),0d};`

This change allows Fongo to interpret the double array as a LatLong
