### PR TITLE
Ensure DBRef have DB set.

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -431,6 +431,12 @@ public class FongoDBCollection extends DBCollection {
           if (nonIdCollection) {
             clonedDbo.removeField(ID_KEY);
           }
+          for (String key : clonedDbo.keySet()) {
+			Object value = clonedDbo.get(key);
+			if (value instanceof DBRef && ((DBRef)value).getDB() == null) {
+				clonedDbo.put(key, new DBRef(this.getDB(),((DBRef) value).getRef(), ((DBRef) value).getId()));
+			}
+          }
           results.add(clonedDbo);
         }
       }

--- a/src/test/java/com/github/fakemongo/FongoTest.java
+++ b/src/test/java/com/github/fakemongo/FongoTest.java
@@ -1142,6 +1142,24 @@ public class FongoTest {
     assertEquals(coll2oid, ref.getId());
     assertEquals(coll2doc, ref.fetch());
   }
+  
+  @Test
+  public void testDbRefsWithoutDbSet() {
+    Fongo fong = newFongo();
+    DB db = fong.getDB("db");
+    DBCollection coll1 = db.getCollection("coll");
+    DBCollection coll2 = db.getCollection("coll2");
+    final String coll2oid = "coll2id";
+    BasicDBObject coll2doc = new BasicDBObject("_id", coll2oid);
+    coll2.insert(coll2doc);
+    coll1.insert(new BasicDBObject("ref", new DBRef(null, "coll2", coll2oid)));
+
+    DBRef ref = (DBRef) coll1.findOne().get("ref");
+    assertNotNull(ref.getDB());
+    assertEquals("coll2", ref.getRef());
+    assertEquals(coll2oid, ref.getId());
+    assertEquals(coll2doc, ref.fetch());
+  }
 
   @Test
   public void testFindAllWithDBList() {


### PR DESCRIPTION
As I was working with nosqlunit, I noticed an odd use case: I insert data from a JSON file into an in memory Fongo. JSON file was having some DBRefs definitions without $db set and as you might guess Fongo was retrieving those DBRefs without it. Any attempt of fetch on such DBRefs ends with an error, indeed db is null !

The main issue is that the Java driver for mongoDB doesn't care of the $db parameter when parsing JSON, as it is stated as optional (see http://docs.mongodb.org/manual/reference/database-references/). So I proposed a patch to nosqlunit in order to insert "proper" data into Fongo. (see https://github.com/lordofthejars/nosql-unit/pull/100)

Nevertheless, It seems that the real MongoDB ensures DBRefs are provided with this $db parameter. So here is a proposition of patch allowing FongoDBCollection to ensure DBRefs are usable as MongoDB does.
