### PR TITLE
Added fix in FongoDBCollection and test in FongoTest for find if only _i...

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -572,6 +572,9 @@ public class FongoDBCollection extends DBCollection {
       ret = new BasicDBObject();
       if (!wasIdExcluded) {
         ret.append(ID_KEY, Util.clone(result.get(ID_KEY)));
+      } else if (inclusionCount == 0) {
+        ret = (BasicDBObject) Util.clone(result);
+        ret.removeField(ID_KEY);
       }
     }
 

--- a/src/test/java/com/github/fakemongo/FongoTest.java
+++ b/src/test/java/com/github/fakemongo/FongoTest.java
@@ -271,6 +271,18 @@ public class FongoTest {
     assertEquals("should return all documents", 5, cursor4.toArray().size());
   }
 
+  @Test
+  public void testFindExcludingOnlyId() {
+    DBCollection collection = newCollection();
+
+    collection.insert(new BasicDBObject("_id", "1").append("a", 1));
+    collection.insert(new BasicDBObject("_id", "2").append("a", 2));
+
+    DBCursor cursor = collection.find(new BasicDBObject(), new BasicDBObject("_id", 0));
+    assertEquals("should have 2 documents", 2, cursor.toArray().size());
+    assertEquals(Arrays.asList(new BasicDBObject("a", 1), new BasicDBObject("a", 2)), cursor.toArray());
+  }
+
   // See http://docs.mongodb.org/manual/reference/operator/elemMatch/
   @Test
   public void testFindElemMatch() {


### PR DESCRIPTION
Added fix in FongoDBCollection and test in FongoTest for find if only _id is excluded. For example, with db {_id:1,a:1}{_id:2,a:2} a find({},{_id:0}) gives {a:1}{a:2} in mongo, but (without fix) {}{} in fongo.
