### PR TITLE
Urjent Fix In TextSerch Sorting

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/text/TextSearch.java
+++ b/src/main/java/com/github/fakemongo/impl/text/TextSearch.java
@@ -12,9 +12,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -61,7 +61,7 @@ public class TextSearch {
   private final DBCollection collection;
   private final Set<String> textIndexFields;
 
-  private final Map results = new HashMap<DBObject, Double>();
+  private final Map<DBObject,Double> results = new LinkedHashMap<DBObject, Double>();
 
   private String searchString;
   private DBObject project;
@@ -183,7 +183,7 @@ public class TextSearch {
       if (resultsNotToInclude.contains(result)) {
         continue;
       } else if (results.containsKey(result)) {
-        score = (Double) results.get(result) + SCORE_INC;
+        score = results.get(result) + SCORE_INC;
       } else {
         score = SCORE_INC;
       }

--- a/src/test/java/com/github/fakemongo/FongoTextSearchTest.java
+++ b/src/test/java/com/github/fakemongo/FongoTextSearchTest.java
@@ -96,15 +96,14 @@ public class FongoTextSearchTest {
 
     assertEquals((DBObject) JSON.parse(
             "{ \"language\" : \"english\" , "
-                    + "\"results\" : [ { "
-                    + "\"score\" : 1.5 , "
-                    + "\"obj\" : { \"_id\" : 2 , \"textField\" : \"ccc ddd\" , \"otherField\" : \"text2 aaa\"}} , { "
-                    + "\"score\" : 1.5 , "
-                    + "\"obj\" : { \"_id\" : 1 , \"textField\" : \"aaa bbb\" , \"otherField\" : \"text1 aaa\"}}] , "
-                    + "\"stats\" : { \"nscannedObjects\" : 6 , \"nscanned\" : 6 , \"n\" : 2 , \"timeMicros\" : 1} , "
-                    + "\"ok\" : 1}"),
+            + "\"results\" : [ "
+            + "{ \"score\" : 1.5 , "
+            + "\"obj\" : { \"_id\" : 1 , \"textField\" : \"aaa bbb\" , \"otherField\" : \"text1 aaa\"}} , "
+            + "{ \"score\" : 1.5 , "
+            + "\"obj\" : { \"_id\" : 2 , \"textField\" : \"ccc ddd\" , \"otherField\" : \"text2 aaa\"}}] , "
+            + "\"stats\" : { \"nscannedObjects\" : 6 , \"nscanned\" : 6 , \"n\" : 2 , \"timeMicros\" : 1} , \"ok\" : 1}"),
             (DBObject) result);
-    assertEquals("aaa bbb",
+    assertEquals("ccc ddd",
             ((DBObject) ((DBObject) ((List) result.get("results")).get(1)).get("obj")).get("textField"));
   }
 }

--- a/src/test/java/com/mongodb/FongoDBCollectionTest.java
+++ b/src/test/java/com/mongodb/FongoDBCollectionTest.java
@@ -259,9 +259,9 @@ public class FongoDBCollectionTest {
       resultsExpected.add(new BasicDBObject("score", 1.5)
               .append("obj", new BasicDBObject("_id", "_id2").append("textField", "eee, abc def")));
       resultsExpected.add(new BasicDBObject("score", 0.75)
-              .append("obj", new BasicDBObject("_id", "_id5").append("textField", "bbb, fff")));
-      resultsExpected.add(new BasicDBObject("score", 0.75)
               .append("obj", new BasicDBObject("_id", "_id4").append("textField", "aaa, bbb")));
+      resultsExpected.add(new BasicDBObject("score", 0.75)
+              .append("obj", new BasicDBObject("_id", "_id5").append("textField", "bbb, fff")));
     DBObject expected = new BasicDBObject("language", "english");
     expected.put("results", resultsExpected);            
     expected.put("stats", 


### PR DESCRIPTION
When I was playing with changing Java Platform for Compilation I found a bug: HashMap with TextSearch find results was filled in unpredictable way... Which gave different results for JDK8 and JDK7.
That resulted the ruing of tests, and differences to Real Mongodb Text Search result I was re-compared our TextSearch results to.
So I've Made this Changes and Everything is OK now.
Sorry for such a dumb mistake...
