### PR TITLE
README: Fix XML typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ It also has a "provided" dependency on sl4j-api for logging.  If you don't alrea
   <groupId>ch.qos.logback</groupId>
   <artifactId>logback-classic</artifactId>
   <version>1.1.1</version>
-  <scope>test</test>
+  <scope>test</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
Fix XML typo in logback's dependency example. Bad closing tag for <scope>.
