### PR TITLE
Adding `travis_wait` for `mvn install`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ jdk:
  - openjdk6
  - oraclejdk8
 
-install: travis_wait mvn install
+install: travis_wait mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V


### PR DESCRIPTION
Adding `travis_wait` to `.travis.yml` to write a log every minute while executing `mvn install` (with default timeout of 20 min.). This _should_ help to get rid all intermittent build failures due to timeouts installing dependencies.

Examples of failed builds due to timeouts:
- https://travis-ci.org/fakemongo/fongo/builds/29705211
- https://travis-ci.org/fakemongo/fongo/builds/29705060
- https://travis-ci.org/fakemongo/fongo/builds/29694848

If this doesn't help, further steps could be increasing the timeout and/or adding `travis_retry`. Please see http://docs.travis-ci.com/user/build-timeouts/

---

@twillouer please review, merge and delete branch.
