### PR TITLE
Include upserted objects in writeresult.

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -244,6 +244,9 @@ public class FongoDBCollection extends DBCollection {
       if (updatedDocuments == 0 && upsert) {
         BasicDBObject newObject = createUpsertObject(q);
         fInsert(updateEngine.doUpdate(newObject, o, q, true), concern);
+        
+        updatedDocuments++;
+        updatedExisting = false;
       }
     }
     return new WriteResult(updateResult(updatedDocuments, updatedExisting), concern);

--- a/src/test/java/com/github/fakemongo/FongoTest.java
+++ b/src/test/java/com/github/fakemongo/FongoTest.java
@@ -773,8 +773,10 @@ public class FongoTest {
     DBObject query = queryBuilder.get();
 
     DBObject update = BasicDBObjectBuilder.start().push("$inc").append("n.!", 1).append("n.a.b:false", 1).pop().get();
-    collection.update(query, update, true, false);
-
+    final WriteResult result = collection.update(query, update, true, false);
+    assertFalse(result.isUpdateOfExisting());
+    assertTrue(result.getN() == 1);
+    
     DBObject expected = queryBuilder.push("n").append("!", 1).push("a").append("b:false", 1).pop().pop().get();
     assertEquals(expected, collection.findOne());
   }


### PR DESCRIPTION
This pull requests will upserted objects to count against the modified documents count (n). The mongo-java-driver will consider all updated and inserted objects of an upsert as _modified_ and therefore count it against the n.

Examples:
- update an existing record: `WriteResult#getN() == 1`
- upsert a non-existing record: `WriteResult#getN() == 1`
- update a non-existing record: `WriteResult#getN() == 0`

---

@twillouer please review, merge and delete the branch.
