### PR TITLE
Handle empty object projection correctly.

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/Util.java
+++ b/src/main/java/com/github/fakemongo/impl/Util.java
@@ -280,4 +280,11 @@ public final class Util {
     }
     return newobj;
   }
+
+  /**
+   * @return true if the projection should not be applied at all
+   */
+  public static boolean isProjectionEmpty(DBObject projection) {
+    return projection == null || projection.keySet().isEmpty();
+  }
 }

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -493,8 +493,7 @@ public class FongoDBCollection extends DBCollection {
       }
     }
 
-    if (fields != null && !fields.keySet().isEmpty()) {
-      LOG.debug("applying projections {}", fields);
+    if (!Util.isProjectionEmpty(fields)) {
       results = applyProjections(results, fields);
     }
 
@@ -640,7 +639,8 @@ public class FongoDBCollection extends DBCollection {
    * TODO: Support for projection operators: http://docs.mongodb.org/manual/reference/operator/projection/
    */
   public static DBObject applyProjections(DBObject result, DBObject projectionObject) {
-    if (projectionObject == null) {
+    LOG.debug("applying projections {}", projectionObject);
+    if (Util.isProjectionEmpty(projectionObject)) {
       return Util.cloneIdFirst(result);
     }
 

--- a/src/test/java/com/github/fakemongo/FongoTest.java
+++ b/src/test/java/com/github/fakemongo/FongoTest.java
@@ -836,6 +836,18 @@ public class FongoTest {
     assertEquals(new BasicDBObject("_id", 1).append("a", 2).append("b", new BasicDBObject("c", 2)), collection.findOne());
   }
 
+  @Test
+  public void testFindAndModifyWithEmptyObjectProjection() {
+    final DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", 1).append("a", 1).append("b", new BasicDBObject("c", 1)));
+
+    final BasicDBObject query = new BasicDBObject("_id", 1);
+    final BasicDBObject update = new BasicDBObject("$unset", new BasicDBObject("b", ""));
+    final DBObject result = collection.findAndModify(query, new BasicDBObject(), null, false, update, true, false);
+
+    assertEquals(new BasicDBObject("_id", 1).append("a", 1), result);
+  }
+
   /**
    * See issue #35
    */


### PR DESCRIPTION
In most cases applying an empty object projection, `{}`, wiped out everything in the returned object except for the id. Changed this to match the mongo behavior.

```
MongoDB shell version: 2.4.5
> db.test.insert({foo:"bar"})
> db.test.find({}, {})
{ "_id" : ObjectId("53ce1dff7391048387657616"), "foo" : "bar" }
```

@twillouer please review, merge and delete the branch.
