### PR TITLE
fixed bug that the $in operator did not compare regex, see example inside

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/ExpressionParser.java
+++ b/src/main/java/com/github/fakemongo/impl/ExpressionParser.java
@@ -324,17 +324,35 @@ public class ExpressionParser {
     boolean compare(Object queryValueIgnored, Object storedValue, Set querySet) {
       if (storedValue instanceof List) {
         for (Object valueItem : (List) storedValue) {
-          if (querySet.contains(valueItem)) {
+          if (containsWithRegex(querySet, valueItem)) {
             return direction;
           }
         }
-        if (querySet.contains(storedValue)) {
+        if (containsWithRegex(querySet, storedValue)) {
           return direction;
         }
         return !direction;
       } else {
-        return !(direction ^ querySet.contains(storedValue));
+        return !(direction ^ containsWithRegex(querySet, storedValue));
       }
+    }
+
+    boolean containsWithRegex(Set querySet, Object storedValue) {
+        if (querySet.contains(storedValue)) {
+            return true;
+        }
+        if (storedValue instanceof CharSequence) {
+            CharSequence s = (CharSequence)storedValue;
+            for (Object o : querySet) {
+                if (o instanceof Pattern) {
+                    Pattern p = (Pattern) o;
+                    if (p.matcher(s).find()) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
   }
 

--- a/src/test/java/com/github/fakemongo/FongoTest.java
+++ b/src/test/java/com/github/fakemongo/FongoTest.java
@@ -247,6 +247,23 @@ public class FongoTest {
     assertNull("should not have the property 'name'", result.get("name"));
   }
 
+   @Test
+   public void testFindInWithRegex() {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", 1));
+    collection.insert(new BasicDBObject("_id", 2));
+    collection.insert(new BasicDBObject("_id", "s"));
+    collection.insert(new BasicDBObject("_id", "a"));
+    collection.insert(new BasicDBObject("_id", "abbb"));
+
+    DBCursor cursor = collection.find(new BasicDBObject("_id", new BasicDBObject("$in", new Object[]{1, "s", Pattern.compile("ab+")})));
+    List<DBObject> dbObjects = cursor.toArray();
+    assertEquals(3, dbObjects.size());
+    assertTrue(dbObjects.contains(new BasicDBObject("_id", 1)));
+    assertTrue(dbObjects.contains(new BasicDBObject("_id", "s")));
+    assertTrue(dbObjects.contains(new BasicDBObject("_id", "abbb")));
+  }
+
   @Test
   public void testFindWithQuery() {
     DBCollection collection = newCollection();


### PR DESCRIPTION
for example: { "x" : "aaa" } did not match: find({"x" : {"$in" : [1234, /a+/, "nomatch"] })
the regex /a+/ should match "aaa" (the others, of course, do not match "aaa")
