### PR TITLE
bugfix for $ne on empty list

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/ExpressionParser.java
+++ b/src/main/java/com/github/fakemongo/impl/ExpressionParser.java
@@ -490,10 +490,9 @@ public class ExpressionParser {
                         return false;
                       }
                     }
-                  } else {
-                    if (isEqual(queryValue, storedValue)) {
-                      return false;
-                    }
+                  }
+                  if (isEqual(queryValue, storedValue)) {
+                    return false;
                   }
                 }
                 return true;

--- a/src/test/java/com/github/fakemongo/impl/ExpressionParserTest.java
+++ b/src/test/java/com/github/fakemongo/impl/ExpressionParserTest.java
@@ -188,6 +188,37 @@ public class ExpressionParserTest {
 	        new BasicDBObject("a", new BasicDBObject("b",  new BasicDBObject("c", 1)))
 	    ), results);
   }
+  @Test
+  public void testNeOperatorWithEmptyList() {
+      BasicDBList listOfSingleItem = new BasicDBList();
+      listOfSingleItem.add(1);
+
+	  DBObject query = new BasicDBObjectBuilder().push("list").add("$ne", new BasicDBList()).pop().get();
+	  List<DBObject> results = doFilter(
+	        query,
+	        new BasicDBObject("list", new BasicDBList()),
+	        new BasicDBObject("list", listOfSingleItem)
+	  );
+	  assertEquals(Arrays.<DBObject>asList(
+              new BasicDBObject("list", listOfSingleItem)
+	  ), results);
+  }
+
+  @Test
+  public void testNeOperatorWithNonEmptyList() {
+      BasicDBList listOfSingleItem = new BasicDBList();
+      listOfSingleItem.add(1);
+
+	  DBObject query = new BasicDBObjectBuilder().push("list").add("$ne", listOfSingleItem).pop().get();
+	  List<DBObject> results = doFilter(
+	        query,
+	        new BasicDBObject("list", new BasicDBList()),
+	        new BasicDBObject("list", listOfSingleItem)
+	  );
+	  assertEquals(Arrays.<DBObject>asList(
+              new BasicDBObject("list", new BasicDBList())
+	  ), results);
+  }
 
   @Test
   public void testNeEmbeddedOperator() {


### PR DESCRIPTION
Using $ne on a list tries to compare the list items, and if it fails, it will compare the list itself (as a whole object), this is the mongo behavior that is fixed in this commit.

Example: { list: [1,2] } should match the query: { list: { $ne: [] } }
