### PR TITLE
FIX: issue #76 (Querying indexed field in subdocument does not work, but works without index)

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/index/IndexAbstract.java
+++ b/src/main/java/com/github/fakemongo/impl/index/IndexAbstract.java
@@ -3,6 +3,7 @@ package com.github.fakemongo.impl.index;
 import com.github.fakemongo.impl.ExpressionParser;
 import com.github.fakemongo.impl.Filter;
 import com.github.fakemongo.impl.Util;
+import com.mongodb.BasicDBList;
 import com.mongodb.DBObject;
 import com.mongodb.FongoDBCollection;
 import com.mongodb.MongoException;
@@ -272,7 +273,7 @@ public abstract class IndexAbstract<T extends DBObject> {
     return true;
   }
 
-  public boolean keyEmbeddedFieldMatch(String field, DBObject queryFields) {
+  private boolean keyEmbeddedFieldMatch(String field, DBObject queryFields) {
     //if field embedded field type
     String[] fieldParts = field.split("\\.");
     if (fieldParts.length == 0) {
@@ -283,7 +284,10 @@ public abstract class IndexAbstract<T extends DBObject> {
     int count = 0;
     for (String fieldPart : fieldParts) {
       count++;
-      if (!searchQueryFields.containsField(fieldPart)) {
+      if (searchQueryFields instanceof BasicDBList) {
+        // when it's a list, there's no need to investigate nested documents
+        return true;
+      } else if (!searchQueryFields.containsField(fieldPart)) {
         return false;
       } else if (searchQueryFields.get(fieldPart) instanceof DBObject) {
         searchQueryFields = (DBObject) searchQueryFields.get(fieldPart);

--- a/src/test/java/com/github/fakemongo/FongoTest.java
+++ b/src/test/java/com/github/fakemongo/FongoTest.java
@@ -174,6 +174,34 @@ public class FongoTest {
     assertEquals(new BasicDBObject("date", 1), result);
   }
 
+  /**
+   * @see <a href="https://github.com/fakemongo/fongo/issues/76">
+   *   Querying indexed field in subdocument does not work, but works without index
+   *   </a>
+   */
+  @Test
+  public void testFindOneIn_within_array_and_given_index_set() {
+    DBCollection collection = newCollection();
+    // prepare documents
+    collection.insert(
+        new BasicDBObject("_id", 1)
+            .append("animals", new BasicDBObject[]{
+                new BasicDBObject("name", "dolphin").append("type", "mammal"),
+            }),
+        new BasicDBObject("_id", 2)
+            .append("animals", new BasicDBObject[]{
+                new BasicDBObject("name", "horse").append("type", "mammal"),
+                new BasicDBObject("name", "shark").append("type", "fish")
+            }));
+    // prepare index
+    collection.createIndex(new BasicDBObject("animals.type", "text"));
+
+    DBObject result = collection.findOne(new BasicDBObject("animals.type", new BasicDBObject("$in", new String[]{"fish"})));
+
+    assertNotNull(result);
+    assertEquals(2, result.get("_id"));
+  }
+
   @Test
   public void testFindOneInWithArray() {
     DBCollection collection = newCollection();


### PR DESCRIPTION
I've added a test, pointing out the problem referred in issue #76 and fixed it ;-)

The root cause seems to be within class IndexAbstract.
When an index was created, it couldn't figure out,
if a BasicDBList within a DBObject contains a field or not.
IMHO if there are arrays within a DBObject, this object should go into the index, to be queried later.

Feedback is welcome.

Regards
Martin
