### PR TITLE
MapReduce fails when when map emits objects {...} as keys 

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/MapReduce.java
+++ b/src/main/java/com/github/fakemongo/impl/MapReduce.java
@@ -259,10 +259,13 @@ public class MapReduce {
 
     // Create variables for exporting.
     sb.append("var $$$fongoEmits$$$ = new Object();\n");
-    sb.append("function emit(param1, param2) { if(typeof $$$fongoEmits$$$[param1] === 'undefined') { " +
-        "$$$fongoEmits$$$[param1] = new Array();" +
+    sb.append("function emit(param1, param2) {\n" +
+        "var toSource = param1.toSource();\n" +
+        "if(typeof $$$fongoEmits$$$[toSource] === 'undefined') {\n " +
+        "$$$fongoEmits$$$[toSource] = new Array();\n" +
         "}\n" +
-        "$$$fongoEmits$$$[param1][$$$fongoEmits$$$[param1].length] = param2;\n" +
+        "var val = {id: param1, value: param2};\n" +
+        "$$$fongoEmits$$$[toSource][$$$fongoEmits$$$[toSource].length] = val;\n" +
         "};\n");
     // Prepare map function.
     sb.append("var fongoMapFunction = ").append(map).append(";\n");
@@ -284,11 +287,12 @@ public class MapReduce {
     sb.setLength(0);
     sb.append("var reduce = ").append(reduce).append("\n");
     sb.append("var $$$fongoOuts$$$ = Array();\n" +
-        "for(i in $$$fongoEmits$$$) {\n" +
-        "$$$fongoOuts$$$[$$$fongoOuts$$$.length] = { _id : i, value : reduce(i, $$$fongoEmits$$$[i]) };\n" +
+        "for(var i in $$$fongoEmits$$$) {\n" +
+        "var elem = $$$fongoEmits$$$[i];\n" +
+        "values = []; id = null; for (var ii in elem) { values.push(elem[ii].value); id = elem[ii].id;}\n" +
+        "$$$fongoOuts$$$[$$$fongoOuts$$$.length] = { _id : id, value : reduce(id, values) };\n" +
         "}\n");
     result.add(sb.toString());
-
     return result;
   }
 

--- a/src/main/java/com/github/fakemongo/impl/MapReduce.java
+++ b/src/main/java/com/github/fakemongo/impl/MapReduce.java
@@ -293,6 +293,7 @@ public class MapReduce {
         "$$$fongoOuts$$$[$$$fongoOuts$$$.length] = { _id : id, value : reduce(id, values) };\n" +
         "}\n");
     result.add(sb.toString());
+
     return result;
   }
 

--- a/src/test/java/com/github/fakemongo/FongoMapReduceTest.java
+++ b/src/test/java/com/github/fakemongo/FongoMapReduceTest.java
@@ -43,6 +43,7 @@ public class FongoMapReduceTest {
     String reduce = "function(key, values){    var res = 0;    values.forEach(function(v){ res += 1});    return {count: res};  };";
     coll.mapReduce(map, reduce, "result", new BasicDBObject());
 
+
     List<DBObject> results = fongoRule.newCollection("result").find().toArray();
     assertEquals(fongoRule.parse("[{ \"_id\" : \"www.google.com\" , \"value\" : { \"count\" : 2.0}}, { \"_id\" : \"www.no-fucking-idea.com\" , \"value\" : { \"count\" : 3.0}}]"), results);
   }

--- a/src/test/java/com/github/fakemongo/FongoMapReduceTest.java
+++ b/src/test/java/com/github/fakemongo/FongoMapReduceTest.java
@@ -43,9 +43,26 @@ public class FongoMapReduceTest {
     String reduce = "function(key, values){    var res = 0;    values.forEach(function(v){ res += 1});    return {count: res};  };";
     coll.mapReduce(map, reduce, "result", new BasicDBObject());
 
-
     List<DBObject> results = fongoRule.newCollection("result").find().toArray();
     assertEquals(fongoRule.parse("[{ \"_id\" : \"www.google.com\" , \"value\" : { \"count\" : 2.0}}, { \"_id\" : \"www.no-fucking-idea.com\" , \"value\" : { \"count\" : 3.0}}]"), results);
+  }
+
+  @Test
+  public void testMapReduceEmitObject() {
+    DBCollection coll = fongoRule.newCollection();
+    fongoRule.insertJSON(coll, "[{url: \"www.google.com\", date: 1, trash_data: 5 },\n" +
+        " {url: \"www.no-fucking-idea.com\", date: 1, trash_data: 13 },\n" +
+        " {url: \"www.google.com\", date: 1, trash_data: 1 },\n" +
+        " {url: \"www.no-fucking-idea.com\", date: 2, trash_data: 69 },\n" +
+        " {url: \"www.no-fucking-idea.com\", date: 2, trash_data: 256 }]");
+
+
+    String map = "function(){    emit({url: this.url}, 1);  };";
+    String reduce = "function(key, values){    var res = 0;    values.forEach(function(v){ res += 1});    return {count: res};  };";
+    coll.mapReduce(map, reduce, "result", new BasicDBObject());
+
+    List<DBObject> results = fongoRule.newCollection("result").find().toArray();
+    assertEquals(fongoRule.parse("[{\"_id\" : {url: \"www.google.com\"} , \"value\" : { \"count\" : 2.0}}, { \"_id\" : {url: \"www.no-fucking-idea.com\"} , \"value\" : { \"count\" : 3.0}}]"), results);
   }
 
     // see http://no-fucking-idea.com/blog/2012/04/01/using-map-reduce-with-mongodb/


### PR DESCRIPTION
Hi,

MapReduce fails when when map emits objects {...} as keys
$$$fongoEmits$$$[param1] was  string "object" in such case

Thanks, 
Vladimir