### PR TITLE
MapReduce Outmode 'reduce', fixed

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/MapReduce.java
+++ b/src/main/java/com/github/fakemongo/impl/MapReduce.java
@@ -309,17 +309,17 @@ public class MapReduce {
     sb.append("var reduce = ").append(reduce).append("\n");
     sb.append("var $$$fongoOuts$$$ = new Array();\n");
     for (DBObject object : objects) {
-      String objectValue = JSON.serialize(object);
-
+      String objectJson = JSON.serialize(object);
+      String objectValueJson = JSON.serialize(object.get("value"));
       DBObject existing = coll.findOne(new BasicDBObject().append(FongoDBCollection.ID_KEY,
           object.get(FongoDBCollection.ID_KEY)));
-      if (existing == null) {
-        sb.append("$$$fongoOuts$$$[$$$fongoOuts$$$.length] = ").append(objectValue).append(";\n");
+      if (existing == null || existing.get("value") == null) {
+        sb.append("$$$fongoOuts$$$[$$$fongoOuts$$$.length] = ").append(objectJson).append(";\n");
       } else {
         String id = JSON.serialize(object.get(FongoDBCollection.ID_KEY));
-        String existingValue = JSON.serialize(existing);
+        String existingValueJson = JSON.serialize(existing.get("value"));
         sb.append("$$$fongoId$$$ = ").append(id).append(";\n");
-        sb.append("$$$fongoValues$$$ = [ ").append(existingValue).append(", ").append(objectValue).append("];\n");
+        sb.append("$$$fongoValues$$$ = [ ").append(existingValueJson).append(", ").append(objectValueJson).append("];\n");
         sb.append("$$$fongoReduced$$$ = { _id : $$$fongoId$$$, value : reduce($$$fongoId$$$, $$$fongoValues$$$)};")
             .append(";\n");
         sb.append("$$$fongoOuts$$$[$$$fongoOuts$$$.length] = $$$fongoReduced$$$;\n");

--- a/src/test/java/com/github/fakemongo/FongoMapReduceOutputModesTest.java
+++ b/src/test/java/com/github/fakemongo/FongoMapReduceOutputModesTest.java
@@ -211,10 +211,10 @@ public class FongoMapReduceOutputModesTest {
     users.insert(user3);
 
     String mapUsers = "function () {" +
-        "emit(this._id, {value : this});" +
+        "emit(this._id, this);" +
         "};";
     String mapUserLogins = "function () {" +
-        "emit(this._id, {value : this});" +
+        "emit(this._id, this);" +
         "};";
     String reduce = "function (id, values) {" +
         "function ifnull(r, v, key) {\n" +
@@ -227,8 +227,7 @@ public class FongoMapReduceOutputModesTest {
         "  }\n" +
         "  res = {};\n" +
         "  for (var i in values) {\n" +
-        "    if (!('value' in values[i])) continue;" +
-        "    res = ifnulls(res, values[i].value, ['_id', 'login', 'type', 'height']);\n" +
+        "    res = ifnulls(res, values[i], ['_id', 'login', 'type', 'height']);\n" +
         "  }\n" +
         "  return res;\n" +
         "}";
@@ -282,14 +281,14 @@ public class FongoMapReduceOutputModesTest {
     users.insert(user3);
 
     String mapUsers = "function () {" +
-        "emit(this._id, {value : this});" +
+        "emit(this._id, this);" +
         "};";
     String mapUserLogins = "function () {" +
-        "emit(this._id, {value : this});" +
+        "emit(this._id, this);" +
         "};";
     String reduce = "function (id, values) {" +
         "function ifnull(r, v, key) {\n" +
-        "  if (v[key] != undefined) r[key] = v[key];\n" +
+        "  if (key in v && v[key] !=null) r[key] = v[key];\n" +
         "  return r;\n" +
         "  }\n" +
         "  function ifnulls(r, v, keys) {\n" +
@@ -298,7 +297,7 @@ public class FongoMapReduceOutputModesTest {
         "  }\n" +
         "  res = {};\n" +
         "  for (var i in values) {\n" +
-        "    res = ifnulls(res, values[i].value, ['_id', 'login', 'type', 'height']);\n" +
+        "    res = ifnulls(res, values[i], ['_id', 'login', 'type', 'height']);\n" +
         "  }\n" +
         "  return res;\n" +
         "}";

--- a/src/test/java/com/github/fakemongo/FongoMapReduceTest.java
+++ b/src/test/java/com/github/fakemongo/FongoMapReduceTest.java
@@ -82,7 +82,7 @@ public class FongoMapReduceTest {
         " {date: \"2\", trash_data: \"256\" }]");
     fongoRule.insertJSON(dates, "[{date: \"1\", dateval: \"10\"}, {date:\"2\", dateval: \"20\"}]");
 
-    String mapTrash = "function() {    emit({date: this.date}, {value : [{trash_data:this.trash_data, date:this.date}]});};";
+    String mapTrash = "function() {    emit({date: this.date}, {value : [{dateval: null, trash_data:this.trash_data, date:this.date}]});};";
     String mapDates = "function() {  emit({date:this.date}, {value : [{dateval:this.dateval}]});};";
     String reduce = "function(key, values){" +
         "    var dateval = null;\n" +
@@ -90,7 +90,7 @@ public class FongoMapReduceTest {
         "        var valArr = values[j].value;\n" +
         "        for (var jj in valArr) {\n" +
         "            var value = valArr[jj];\n" +
-        "            if ('dateval' in value) {\n" +
+        "            if (value.dateval !== null) {\n" +
         "                dateval = value.dateval;\n" +
         "            }\n" +
         "        }\n" +

--- a/src/test/java/com/github/fakemongo/FongoMapReduceTest.java
+++ b/src/test/java/com/github/fakemongo/FongoMapReduceTest.java
@@ -7,8 +7,12 @@ import com.mongodb.DBObject;
 import com.mongodb.MapReduceCommand;
 import com.mongodb.MapReduceOutput;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import static org.junit.Assert.assertEquals;
+import com.mongodb.util.JSON;
+import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -68,16 +72,17 @@ public class FongoMapReduceTest {
 
   @Test
   public void testMapReduceJoinOneToMany() {
-    DBCollection urls = fongoRule.newCollection();
+    DBCollection trash = fongoRule.newCollection();
     DBCollection dates = fongoRule.newCollection();
 
-    fongoRule.insertJSON(urls, "[{url: \"www.google.com\", date: \"1\", trash_data: \"5\" },\n" +
-        " {url: \"www.no-fucking-idea.com\", date: \"1\", trash_data: \"13\" },\n" +
-        " {url: \"www.google.com\", date: \"1\", trash_data: \"1\" },\n" +
-        " {url: \"www.no-fucking-idea.com\", date: \"2\", trash_data: \"256\" }]");
+    fongoRule.insertJSON(trash, "[" +
+        " {date: \"1\", trash_data: \"13\" },\n" +
+        " {date: \"1\", trash_data: \"1\" },\n" +
+        " {date: \"2\", trash_data: \"100\" },\n" +
+        " {date: \"2\", trash_data: \"256\" }]");
     fongoRule.insertJSON(dates, "[{date: \"1\", dateval: \"10\"}, {date:\"2\", dateval: \"20\"}]");
 
-    String mapUrls = "function() {    emit({date: this.date}, {value : [{url:this.url, date:this.date}]});};";
+    String mapTrash = "function() {    emit({date: this.date}, {value : [{trash_data:this.trash_data, date:this.date}]});};";
     String mapDates = "function() {  emit({date:this.date}, {value : [{dateval:this.dateval}]});};";
     String reduce = "function(key, values){" +
         "    var dateval = null;\n" +
@@ -85,7 +90,7 @@ public class FongoMapReduceTest {
         "        var valArr = values[j].value;\n" +
         "        for (var jj in valArr) {\n" +
         "            var value = valArr[jj];\n" +
-        "            if (value.dateval !== null) {\n" +
+        "            if ('dateval' in value) {\n" +
         "                dateval = value.dateval;\n" +
         "            }\n" +
         "        }\n" +
@@ -99,22 +104,37 @@ public class FongoMapReduceTest {
         "            for (var jjj in orig) {\n" +
         "             copy[jjj] = orig[jjj];\n" +
         "            }\n" +
-        "            copy[\"dateval\"] = dateval;\n" +
+        "            if (dateval !== null) {\n" +
+        "                copy[\"dateval\"] = dateval;\n" +
+        "            }\n" +
         "            outValues.push(copy);\n" +
         "        }\n" +
         "    }\n" +
         "    return {value:outValues};" +
         "};";
-    urls.mapReduce(mapUrls, reduce, "result", MapReduceCommand.OutputType.REDUCE, new BasicDBObject());
+    trash.mapReduce(mapTrash, reduce, "result", MapReduceCommand.OutputType.REDUCE, new BasicDBObject());
     dates.mapReduce(mapDates, reduce, "result", MapReduceCommand.OutputType.REDUCE, new BasicDBObject());
-    urls.find().toArray();
-    dates.find().toArray();
     List<DBObject> results = fongoRule.newCollection("result").find().toArray();
-    assertEquals(fongoRule.parse("[{ \"_id\" : { \"date\" : \"1\"} , " +
-        "\"value\" : { \"value\" : [ { \"dateval\" : \"10\"} , { \"url\" : \"www.google.com\" , \"date\" : \"1\" , \"dateval\" : \"10\"} , " +
-        "{ \"url\" : \"www.no-fucking-idea.com\" , \"date\" : \"1\" , \"dateval\" : \"10\"} , " +
-        "{ \"url\" : \"www.google.com\" , \"date\" : \"1\" , \"dateval\" : \"10\"}]}}, { \"_id\" : { \"date\" : \"2\"} , " +
-        "\"value\" : { \"value\" : [ { } , { \"url\" : \"www.no-fucking-idea.com\" , \"date\" : \"2\"}]}}]"), results);
+    Map<String, DBObject> byId = new HashMap<String, DBObject>();
+    for (DBObject res : results) {
+      byId.put(JSON.serialize(res.get("_id")), res);
+    }
+    List<DBObject> expected = fongoRule.parse("[" +
+        "{\"_id\":{\"date\":\"1\"}, \"value\":" +
+        "{\"value\":[{\"dateval\":\"10\"}, {\"trash_data\":\"13\", \"date\":\"1\", \"dateval\":\"10\"}, " +
+        "{\"trash_data\":\"1\", \"date\":\"1\", \"dateval\":\"10\"}]}}, " +
+        "{\"_id\":{\"date\":\"2\"}, \"value\":" +
+        "{\"value\":[{\"dateval\":\"20\"}, {\"trash_data\":\"100\", \"date\":\"2\", \"dateval\":\"20\"}, " +
+        "{\"trash_data\":\"256\", \"date\":\"2\", \"dateval\":\"20\"}]}}]");
+    for (DBObject e : expected) {
+      List<DBObject> values = (List<DBObject>)(((DBObject) e.get("value")).get("value"));
+      DBObject id = (DBObject) e.get("_id");
+      DBObject actual = byId.get(JSON.serialize(id));
+      List<DBObject> actualValues = (List<DBObject>)(((DBObject) actual.get("value")).get("value"));
+      Assertions.assertThat(actualValues).containsAll(values);
+      Assertions.assertThat(actualValues.size()).isEqualTo(values.size());
+    }
+    Assertions.assertThat(expected.size()).isEqualTo(results.size());
   }
 
     // see http://no-fucking-idea.com/blog/2012/04/01/using-map-reduce-with-mongodb/


### PR DESCRIPTION
Hi :)

I've fixed a mistake in 'reduce' stage,
I was calling reduce(id, values), values=[existing, new], but should've been using
values = [existing.value, new.value], sorry

wrote a test 'testMapReduceJoinOneToMany' to confirm fongo and mongo does reduce stage identically.