### PR TITLE
Fix #102. Manage FongoDB#eval() to be able to execute instructions as string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,4 @@ Version 1.6.0 break compatibility with 2.12.X driver version.
 * [Martin W. Kirst](https://github.com/nitram509)
 * [LiBe](https://github.com/libetl)
 * [Vladimir Shakhov](https://github.com/bogdad)
+* [Pierre-Jean Vardanega](https://github.com/pvardanega)

--- a/src/main/java/com/mongodb/FongoDB.java
+++ b/src/main/java/com/mongodb/FongoDB.java
@@ -1,8 +1,5 @@
 package com.mongodb;
 
-import com.github.fakemongo.Fongo;
-import com.github.fakemongo.impl.Aggregator;
-import com.github.fakemongo.impl.MapReduce;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -13,6 +10,9 @@ import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.github.fakemongo.Fongo;
+import com.github.fakemongo.impl.Aggregator;
+import com.github.fakemongo.impl.MapReduce;
 
 /**
  * fongo override of com.mongodb.DB
@@ -163,7 +163,11 @@ public class FongoDB extends DB {
     if (LOG.isDebugEnabled()) {
       LOG.debug("Fongo got command " + cmd);
     }
-    if (cmd.containsField("getlasterror") || cmd.containsField("getLastError")) {
+    if (cmd.containsField("$eval")) {
+        CommandResult commandResult = okResult();
+        commandResult.append("retval", "null");
+        return commandResult;
+    } else if (cmd.containsField("getlasterror") || cmd.containsField("getLastError")) {
       return okResult();
     } else if (cmd.containsField("fsync")) {
       return okResult();

--- a/src/test/java/com/mongodb/FongoDBTest.java
+++ b/src/test/java/com/mongodb/FongoDBTest.java
@@ -1,9 +1,10 @@
 package com.mongodb;
 
-import com.github.fakemongo.Fongo;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import com.github.fakemongo.Fongo;
 
 /**
  * @author Anton Bobukh <abobukh@yandex-team.ru>
@@ -62,6 +63,21 @@ public class FongoDBTest {
 
     command = new BasicDBObject("mapReduce", "test").append("out", new BasicDBObject("inline", 1));
     Assert.assertTrue(db.command(command, options, preference).containsField("results"));
+  }
+
+  @Test
+  public void commandEvalString() {
+      DBObject command = BasicDBObjectBuilder.
+              start().
+              add("$eval", "(function() {db.dropDatabase();\ndb.users.createIndex( { email: 1 }, { unique: true } );\n})();").
+              add("args", new Object[0]).
+              get();
+
+      CommandResult result = db.command(command);
+
+      assertThat(result.get("ok")).isEqualTo(1.0);
+      assertThat(result.get("retval")).isNotNull();
+      assertThat(result.get("errmsg")).isNull();
   }
 
 }


### PR DESCRIPTION
See issue _Command `$eval` not managed by FongoDB_ https://github.com/fakemongo/fongo/issues/102

The `retval` should always be returned, even if the value is a string containing _null_.