### PR TITLE
Added support for the $out (aggregation) operator. 

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/Aggregator.java
+++ b/src/main/java/com/github/fakemongo/impl/Aggregator.java
@@ -1,13 +1,6 @@
 package com.github.fakemongo.impl;
 
-import com.github.fakemongo.impl.aggregation.Group;
-import com.github.fakemongo.impl.aggregation.Limit;
-import com.github.fakemongo.impl.aggregation.Match;
-import com.github.fakemongo.impl.aggregation.PipelineKeyword;
-import com.github.fakemongo.impl.aggregation.Project;
-import com.github.fakemongo.impl.aggregation.Skip;
-import com.github.fakemongo.impl.aggregation.Sort;
-import com.github.fakemongo.impl.aggregation.Unwind;
+import com.github.fakemongo.impl.aggregation.*;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.FongoDB;
@@ -27,7 +20,7 @@ public class Aggregator {
   private final FongoDB fongoDB;
   private final FongoDBCollection fongoDBCollection;
   private final List<DBObject> pipeline;
-  private static final List<PipelineKeyword> keywords = Arrays.asList(Match.INSTANCE, Project.INSTANCE, Group.INSTANCE, Sort.INSTANCE, Limit.INSTANCE, Skip.INSTANCE, Unwind.INSTANCE);
+  private static final List<PipelineKeyword> keywords = Arrays.asList(Match.INSTANCE, Project.INSTANCE, Group.INSTANCE, Sort.INSTANCE, Limit.INSTANCE, Skip.INSTANCE, Unwind.INSTANCE, Out.INSTANCE);
 
   public Aggregator(FongoDB fongoDB, FongoDBCollection coll, List<DBObject> pipeline) {
     this.fongoDB = fongoDB;

--- a/src/main/java/com/github/fakemongo/impl/aggregation/Out.java
+++ b/src/main/java/com/github/fakemongo/impl/aggregation/Out.java
@@ -1,0 +1,28 @@
+package com.github.fakemongo.impl.aggregation;
+
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+
+import java.util.List;
+
+/**
+ * User: gdepourtales
+ * 2015/06/15
+ */
+public class Out extends PipelineKeyword {
+
+    public static final Out INSTANCE = new Out();
+
+    @Override
+    public DBCollection apply(DBCollection coll, DBObject object) {
+        List<DBObject> objects = coll.find().toArray();
+        DBCollection newCollection = coll.getDB().getCollection(object.get(getKeyword()).toString());
+        newCollection.insert(objects);
+        return coll;
+    }
+
+    @Override
+    public String getKeyword() {
+        return "$out";
+    }
+}

--- a/src/test/java/com/github/fakemongo/FongoAggregateOutTest.java
+++ b/src/test/java/com/github/fakemongo/FongoAggregateOutTest.java
@@ -1,0 +1,125 @@
+package com.github.fakemongo;
+
+import com.github.fakemongo.junit.FongoRule;
+import com.mongodb.AggregationOutput;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.util.JSON;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * User: gdepourtales
+ * 2015/06/15
+ */
+public class FongoAggregateOutTest {
+
+    public final FongoRule fongoRule = new FongoRule(false);
+
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Rule
+    public TestRule rules = RuleChain.outerRule(exception).around(fongoRule);
+
+    /**
+     * See http://docs.mongodb.org/manual/reference/operator/aggregation/out/#pipe._S_out
+     */
+    @Test
+    public void testOut() {
+        DBCollection coll = fongoRule.newCollection();
+        DBCollection secondCollection = fongoRule.newCollection();
+        String data = "[{ _id: 1, sec: \"dessert\", category: \"pie\", type: \"apple\" },\n" +
+                "{ _id: 2, sec: \"dessert\", category: \"pie\", type: \"cherry\" },\n" +
+                "{ _id: 3, sec: \"main\", category: \"pie\", type: \"shepherd's\" },\n" +
+                "{ _id: 4, sec: \"main\", category: \"pie\", type: \"chicken pot\" }]";
+        fongoRule.insertJSON(coll, data);
+
+        DBObject project = fongoRule.parseDBObject(
+                "{ $out: \"" + secondCollection.getName() + "\"}"
+            );
+
+        AggregationOutput output = coll.aggregate(Arrays.asList(project));
+        assertTrue(output.getCommandResult().ok());
+
+        List<DBObject> result = (List<DBObject>) output.getCommandResult().get("result");
+        assertNotNull(result);
+        assertEquals(fongoRule.parse(data), result);
+        assertEquals(4, secondCollection.count());
+        assertEquals("apple", secondCollection.find(fongoRule.parseDBObject("{_id:1}")).next().get("type"));
+        assertEquals("pie", secondCollection.find(fongoRule.parseDBObject("{_id:1}")).next().get("category"));
+        assertEquals("chicken pot", secondCollection.find(fongoRule.parseDBObject("{_id:4}")).next().get("type"));
+
+
+        // Clean up second collection
+        secondCollection.drop();
+    }
+
+
+    /**
+     * See http://docs.mongodb.org/manual/reference/operator/aggregation/out/#pipe._S_out
+     */
+    @Test
+    public void testOutWithEmptyCollection() {
+        DBCollection coll = fongoRule.newCollection();
+        DBCollection secondCollection = fongoRule.newCollection();
+        String data = "[]";
+        fongoRule.insertJSON(coll, data);
+
+        DBObject project = fongoRule.parseDBObject(
+                "{ $out: \"" + secondCollection.getName() + "\"}"
+        );
+
+        AggregationOutput output = coll.aggregate(Arrays.asList(project));
+        assertTrue(output.getCommandResult().ok());
+
+        List<DBObject> result = (List<DBObject>) output.getCommandResult().get("result");
+        assertNotNull(result);
+        assertEquals(fongoRule.parse(data), result);
+        assertEquals(0, secondCollection.count());
+        // Clean up second collection
+        secondCollection.drop();
+    }
+
+    /**
+     * See http://docs.mongodb.org/manual/reference/operator/aggregation/out/#pipe._S_out
+     */
+    @Test
+    public void testOutWithNonExistentCollection() {
+        DBCollection coll = fongoRule.newCollection();
+        String data = "[{ _id: 1, sec: \"dessert\", category: \"pie\", type: \"apple\" },\n" +
+                "{ _id: 2, sec: \"dessert\", category: \"pie\", type: \"cherry\" },\n" +
+                "{ _id: 3, sec: \"main\", category: \"pie\", type: \"shepherd's\" } ,\n" +
+                "{ _id: 4, sec: \"main\", category: \"pie\", type: \"chicken pot\" }]";
+        fongoRule.insertJSON(coll, data);
+        String newCollectionName = "new_collection";
+
+        DBObject project = fongoRule.parseDBObject(
+                "{ $out: \"" + newCollectionName + "\"}"
+        );
+
+        AggregationOutput output = coll.aggregate(Arrays.asList(project));
+        assertTrue(output.getCommandResult().ok());
+
+        List<DBObject> result = (List<DBObject>) output.getCommandResult().get("result");
+        assertNotNull(result);
+        assertEquals(fongoRule.parse(data), result);
+        DBCollection newCollection = fongoRule.getDB().getCollection("new_collection");
+        assertEquals(4, newCollection.count());
+        assertEquals("apple", newCollection.find(fongoRule.parseDBObject("{_id:1}")).next().get("type"));
+        assertEquals("pie", newCollection.find(fongoRule.parseDBObject("{_id:1}")).next().get("category"));
+        assertEquals("chicken pot", newCollection.find(fongoRule.parseDBObject("{_id:4}")).next().get("type"));
+
+        // Clean up second collection
+        newCollection.drop();
+    }
+}


### PR DESCRIPTION
Added support for the $out aggregation operator. The operator creates if required a new collection and inserts the object of the incoming collection. It returns the original collection as result

See http://docs.mongodb.org/manual/reference/operator/aggregation/out/#pipe._S_out