### PR TITLE
fixed copying issue with byte[] in nested fields

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/Util.java
+++ b/src/main/java/com/github/fakemongo/impl/Util.java
@@ -210,7 +210,7 @@ public final class Util {
       }
     }
     if (source instanceof byte[]) {
-      return new Binary((byte[]) source);
+      return source;
     }
 //    }
 //    if(source instanceof Cloneable) {

--- a/src/test/java/com/github/fakemongo/FongoTest.java
+++ b/src/test/java/com/github/fakemongo/FongoTest.java
@@ -2076,6 +2076,28 @@ public class FongoTest {
     assertThat(result.get(0).get("date")).isEqualTo(12);
   }
 
+
+    @Test
+    public void testBinarySaveWithNestedByteArray() throws Exception {
+      // Given
+      DBCollection collection = newCollection();
+
+      byte[] byteArray = "nestedByteArray".getBytes();
+      DBObject innerField = BasicDBObjectBuilder.start().add("value" , byteArray).get();
+
+      // When
+      collection.insert(BasicDBObjectBuilder.start().add("_id", 1).add("nested", innerField).get());
+
+      // Then
+      List<DBObject> result = collection.find().toArray();
+      assertThat(result).hasSize(1);
+      assertThat(result.get(0).keySet()).containsExactly("_id", "nested");
+      assertThat(result.get(0).get("_id")).isEqualTo(1);
+      assertThat(DBObject.class.isAssignableFrom(result.get(0).get("nested").getClass()));
+      assertThat(((DBObject)result.get(0).get("nested")).get("value")).isEqualTo("nestedByteArray".getBytes());
+    }
+
+
   // can not change _id of a document query={ "_id" : "52986f667f6cc746624b0db5"}, document={ "name" : "Robert" , "_id" : { "$oid" : "52986f667f6cc746624b0db5"}}
   // See jongo SaveTest#canSaveWithObjectIdAsString
   @Test


### PR DESCRIPTION
first time pull-requester.
bug: Saving a document with a nested byte array would throw an error when reading the document out.  Util.java was copying over the field as a Binary object instead of byte[] (which is what the mongo-driver's BasicBSONEncoder uses for byte[]).  changed Util.java to just copy the raw byte[].  

Test case included.