### PR TITLE
Make an explicit copy of array when cloning byte array field

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/Util.java
+++ b/src/main/java/com/github/fakemongo/impl/Util.java
@@ -210,13 +210,22 @@ public final class Util {
       }
     }
     if (source instanceof byte[]) {
-      return source;
+      return makeCopy((byte[]) source);
     }
 //    }
 //    if(source instanceof Cloneable) {
 //      return ((Cloneable) source).clone();
 //    }
     return source;
+  }
+
+  private static byte[] makeCopy(byte[] source) {
+    if (source == null) {
+      return null;
+    }
+    final byte[] copy = new byte[source.length];
+    System.arraycopy(source, 0, copy, 0, source.length);
+    return copy;
   }
 
   public static <T extends DBObject> T clone(T source) {

--- a/src/test/java/com/github/fakemongo/FongoGridFSTest.java
+++ b/src/test/java/com/github/fakemongo/FongoGridFSTest.java
@@ -1,0 +1,45 @@
+package com.github.fakemongo;
+
+import com.github.fakemongo.junit.FongoRule;
+import com.mongodb.gridfs.GridFS;
+import com.mongodb.gridfs.GridFSDBFile;
+import com.mongodb.gridfs.GridFSInputFile;
+import org.bson.types.ObjectId;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class FongoGridFSTest {
+
+  @Rule
+  public final FongoRule fongoRule = new FongoRule(false);
+
+  private GridFS fs;
+
+  @Before
+  public void setUp() throws Exception {
+    fs = new GridFS(fongoRule.getDB());
+  }
+
+  @Test
+  public void shouldStoreFileInMultipleChunks() throws Exception {
+    final byte[] data = new byte[]{1, 2, 3, 4, 5};
+
+    final GridFSInputFile file = fs.createFile(data);
+    file.setChunkSize(3); //chunk size is less than data size in order to get more than one chunk
+    file.save();
+
+    final GridFSDBFile result = fs.findOne((ObjectId) file.getId());
+
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    assertEquals(data.length, result.writeTo(out));
+
+    assertArrayEquals(data, out.toByteArray());
+  }
+
+}


### PR DESCRIPTION
Issue: when persisting GridFS file the internal buffer array instance is assigned to Fongo field. In case of multiple chunks, the same buffer array instance is reused for reading input. Since the same buffer instance is shared among all chunks, data in all chunks is overwritten with the latest chunk content.
As a solution input byte array must be explicitly copied, so that every chunk will get its own copy