### PR TITLE
Added a fix around the null handling in the $in expression

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/ExpressionParser.java
+++ b/src/main/java/com/github/fakemongo/impl/ExpressionParser.java
@@ -1115,7 +1115,9 @@ public class ExpressionParser {
         public boolean apply(DBObject o) {
           List<Object> storedList = getEmbeddedValues(path, o);
           if (storedList.isEmpty()) {
-            return !direction;
+            // Special case: Querying for null should return positive if the field is absent.
+            // See: http://docs.mongodb.org/manual/faq/developers/#faq-developers-query-for-nulls
+            return querySet.contains(null) ? direction : !direction;
           } else {
             for (Object storedValue : storedList) {
               if (compare(refExpression.get(command), storedValue, querySet) == direction) {

--- a/src/test/java/com/github/fakemongo/impl/ExpressionParserTest.java
+++ b/src/test/java/com/github/fakemongo/impl/ExpressionParserTest.java
@@ -308,6 +308,25 @@ public class ExpressionParserTest {
   }
 
   @Test
+  public void testInOperatorWithNullValue() {
+    // Querying for null should return positive if the field is absent.
+    // See: http://docs.mongodb.org/manual/faq/developers/#faq-developers-query-for-nulls
+    DBObject query = new BasicDBObjectBuilder().push("a").add("$in", asList(2, 3, null)).pop().get();
+    List<DBObject> results = doFilter(
+        query,
+        new BasicDBObject("a", asList(1, 3)),
+        new BasicDBObject("a", 1),
+        new BasicDBObject("a", 3),
+        new BasicDBObject("b", 1)
+    );
+    assertEquals(Arrays.<DBObject>asList(
+        new BasicDBObject("a", asList(1, 3)),
+        new BasicDBObject("a", 3),
+        new BasicDBObject("b", 1)
+    ), results);
+  }
+
+  @Test
   public void testInEmbeddedOperator() {
     DBObject query = new BasicDBObject("a.b", new BasicDBObject("$in", asList(2)));
     List<DBObject> results = doFilter(


### PR DESCRIPTION
This is to address the issue around the improper null handling in the $in expression, 
https://github.com/fakemongo/fongo/issues/144.

In summary, passing a null value to the `$in` operator [should get back items that are missing the field](http://docs.mongodb.org/manual/faq/developers/#faq-developers-query-for-nulls) on which it is associated with. This one-liner change should align Fongo with the behaviour of MongoDB. The unit-test in this pull request should illustrate the scenario better than I can explain. :smile: 