### PR TITLE
fix #159, allow adjustment of Mongo version

### DIFF
--- a/src/main/java/com/mongodb/FongoDB.java
+++ b/src/main/java/com/mongodb/FongoDB.java
@@ -246,7 +246,8 @@ public class FongoDB extends DB {
       return okResult();
     } else if (cmd.containsField("buildInfo") || cmd.containsField("buildinfo")) {
       CommandResult okResult = okResult();
-      okResult.put("version", "2.4.5");
+      List<Integer> versionList = fongo.getServerVersion().getVersionList();
+      okResult.put("version", versionList.get(0) + "." + versionList.get(1) + "." + versionList.get(2));
       okResult.put("maxBsonObjectSize", 16777216);
       return okResult;
     } else if (cmd.containsField("forceerror")) {

--- a/src/test/java/com/mongodb/FongoDBTest.java
+++ b/src/test/java/com/mongodb/FongoDBTest.java
@@ -1,12 +1,15 @@
 package com.mongodb;
 
+import com.github.fakemongo.Fongo;
 import com.github.fakemongo.junit.FongoRule;
+import com.mongodb.connection.ServerVersion;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.springframework.util.StringUtils;
 
 /**
  * @author Anton Bobukh <abobukh@yandex-team.ru>
@@ -62,6 +65,20 @@ public class FongoDBTest {
 
     command = new BasicDBObject("buildInfo", 1);
     Assert.assertTrue(db.command(command, preference).containsField("version"));
+  }
+
+  @Test
+  public void commandBuildInfoPullsDefaultMongoVersionFromFongo() throws Exception {
+    CommandResult commandResult = db.command("buildInfo");
+    String expectedVersionAsString = StringUtils.collectionToDelimitedString(Fongo.DEFAULT_SERVER_VERSION.getVersionList(), ".");
+    assertThat(commandResult.getString("version")).isEqualTo(expectedVersionAsString);
+  }
+
+  @Test
+  public void commandBuildInfoPullsChangedMongoVersionFromFongo() throws Exception {
+      db = new Fongo("testfongo", new ServerVersion(3, 1)).getDB("testdb");
+      CommandResult commandResult = db.command("buildInfo");
+      assertThat(commandResult.getString("version")).isEqualTo("3.1.0");
   }
 
   @Test


### PR DESCRIPTION
Tried to be minimally invasive, otherwise I would've refactored a little more.

There was no means to join Strings in compile scope, but found the Spring StringUtils in the test scope making the test-code a little cleaner.