### PR TITLE
PerfTest are using JMH framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,18 @@
             <version>${scala.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.11.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.5.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/github/fakemongo/PerfTest.java
+++ b/src/test/java/com/github/fakemongo/PerfTest.java
@@ -87,6 +87,23 @@ public class PerfTest {
   }
 
   @Benchmark
+  public void doitRemoveWithIndex() {
+    DB db = fongo.getDB("db");
+    DBCollection collection = db.getCollection("coll");
+    collection.createIndex(new BasicDBObject("n", 1));
+
+    for (int k = 0; k < size; k++) {
+        collection.insert(new BasicDBObject("_id", k).append("n", k % 100));
+    }
+
+    for (int k = 0; k < size; k++) {
+      collection.remove(new BasicDBObject("n.a", k % 100));
+    }
+
+      db.dropDatabase();
+    }
+
+  @Benchmark
   public void doitRemoveWithIndexNew() {
     MongoDatabase db = fongo.getDatabase("db");
     MongoCollection<Document> collection = db.getCollection("coll");


### PR DESCRIPTION
> JMH is a Java harness for building, running, and analysing nano/micro/milli/macro benchmarks written in Java and other languages targetting the JVM. - [Official web site](http://openjdk.java.net/projects/code-tools/jmh/)

JMH is a part of OpenJDK project.

It has several important benefits:
+ Each benchmark are running in dedicated JVM
+ A lot of information about warmup and measurement stages
+ Output contains a lot of information

My results for V3 and for master:
V3 branch
```
PerfTest.doit                    thrpt   20  57.217 ± 0.971  ops/s
PerfTest.doitFindN               thrpt   20  13.059 ± 0.214  ops/s
PerfTest.doitFindNWithIndex      thrpt   20   8.314 ± 0.195  ops/s
PerfTest.doitFindUniqueIndex     thrpt   20  51.721 ± 4.198  ops/s
--
PerfTest.doitRemoveWithIndex     thrpt   20   6.497 ± 0.259  ops/s
PerfTest.doitRemoveWithIndexNew  thrpt   20   4.413 ± 0.171  ops/s
```
Master branch
```
PerfTest.doit                 thrpt   20  64.399 ± 2.285  ops/s
PerfTest.doitFindN            thrpt   20  13.077 ± 0.240  ops/s
PerfTest.doitFindNWithIndex   thrpt   20   7.971 ± 0.196  ops/s
PerfTest.doitFindUniqueIndex  thrpt   20  51.774 ± 3.218  ops/s
```

Output example for some of benchmarks:
```
# Warmup Iteration   1: 1.954 ops/s
# Warmup Iteration   2: 13.810 ops/s
# Warmup Iteration   3: 19.900 ops/s
# Warmup Iteration   4: 30.557 ops/s
# Warmup Iteration   5: 60.593 ops/s
...
# Warmup Iteration   9: 60.964 ops/s
# Warmup Iteration  10: 63.656 ops/s
Iteration   1: 63.727 ops/s
...
Iteration  20: 64.595 ops/s
```
I used 10 warmup iterations because how output shows we have a transient system that are going to plateau after 5 iterations. But it's nice to be sure in it :)
20 iterations guarantee small inaccuracy in results and small execution time.

Ops/s means operations in second - how much such operation we can process in one second.