### PR TITLE
closes #183: Fongo treating updates like upserts?

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -283,8 +283,10 @@ public class FongoDBCollection extends DBCollection {
         o.put(ID_KEY, Util.clone(o.get(ID_KEY)));
       }
       @SuppressWarnings("unchecked") Iterator<DBObject> oldObjects = _idIndex.retrieveObjects(q).iterator();
-      addToIndexes(Util.clone(o), oldObjects.hasNext() ? oldObjects.next() : null, concern);
-      updatedDocuments++;
+      if (oldObjects.hasNext() || upsert) {
+        addToIndexes(Util.clone(o), oldObjects.hasNext() ? oldObjects.next() : null, concern);
+        updatedDocuments++;
+      }
     } else {
       Filter filter = expressionParser.buildFilter(q);
       for (DBObject obj : filterByIndexes(q)) {

--- a/src/test/java/com/github/fakemongo/FongoTest.java
+++ b/src/test/java/com/github/fakemongo/FongoTest.java
@@ -802,6 +802,14 @@ public class FongoTest {
   }
 
   @Test
+  public void testUpdateNotExistingById() {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", 1).append("n", "1"));
+    collection.update(new BasicDBObject("_id", 2), new BasicDBObject("n", "2"));
+    assertEquals(1, collection.find().size());
+  }
+
+  @Test
   public void testUpdateWithObjectId() {
     DBCollection collection = newCollection();
     collection.insert(new BasicDBObject("_id", new BasicDBObject("n", 1)));


### PR DESCRIPTION
Fix updating non-existing document by id that resulted in upsert regardless of upsert option