### PR TITLE
Fixes Travis CI: Isolate JMH PerfTest in separate profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,18 +178,6 @@
             <version>${scala.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-core</artifactId>
-            <version>1.11.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.openjdk.jmh</groupId>
-            <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.5.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -202,6 +190,9 @@
                     <source>1.6</source>
                     <target>1.6</target>
                     <encoding>UTF-8</encoding>
+                    <testExcludes>
+                        <exclude>com/github/fakemongo/PerfTest.java</exclude>
+                    </testExcludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -258,6 +249,9 @@
                     <argLine>${jacoco.argLine.unit}
                         -Dfile.encoding=${project.build.sourceEncoding} -Xmx512m
                     </argLine>
+                    <excludes>
+                        <exclude>com/github/fakemongo/PerfTest.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>
@@ -434,6 +428,63 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>perf-benchmark</id>
+            <activation>
+                <property>
+                    <name>perfBenchmark</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.openjdk.jmh</groupId>
+                    <artifactId>jmh-core</artifactId>
+                    <version>1.11.2</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.openjdk.jmh</groupId>
+                    <artifactId>jmh-generator-annprocess</artifactId>
+                    <version>1.5.1</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${version.surefire}</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.apache.maven.surefire</groupId>
+                                <artifactId>surefire-junit47</artifactId>
+                                <version>${version.surefire}</version>
+                            </dependency>
+                        </dependencies>
+                        <configuration>
+                            <includes>
+                                <include>com/github/fakemongo/PerfTest.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.2</version>
+                        <configuration>
+                            <source>1.6</source>
+                            <target>1.6</target>
+                            <encoding>UTF-8</encoding>
+                            <testIncludes>
+                                <include>com/github/fakemongo/PerfTest.java</include>
+                            </testIncludes>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Moves the JMH benchmark stuff into a separate Maven profile (perf-benchmark) that is activated by passing -DperfBenchmark=true.  Excludes JMH deps & test from regular build so Travis install/test cycle works w/o requiring a clean.