### PR TITLE
Exception missmatch between Fongo and MongoDB on findAndModify with unique index

### DIFF
--- a/src/main/java/com/mongodb/FongoDB.java
+++ b/src/main/java/com/mongodb/FongoDB.java
@@ -435,6 +435,11 @@ public class FongoDB extends DB {
     return new DuplicateKeyException(result, fongo.getServerAddress(), WriteConcernResult.unacknowledged());
   }
 
+  public MongoCommandException mongoCommandException(int code, String err) {
+     final BsonDocument result = bsonResultNotOk(code, err);
+     return new MongoCommandException(result, fongo.getServerAddress());
+  }
+
   public CommandResult notOkErrorResult(int code, String err, String errmsg) {
     CommandResult result = notOkErrorResult(err, errmsg);
     result.put("code", code);

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -1328,7 +1328,14 @@ public class FongoDBCollection extends DBCollection {
       if (!error.isEmpty()) {
         // TODO formatting : E11000 duplicate key error index: test.zip.$city_1_state_1_pop_1  dup key: { : "BARRE", : "MA", : 4546.0 }
         if (enforceDuplicates(concern)) {
-          throw fongoDb.duplicateKeyException(11000, "E11000 duplicate key error index: " + this.getFullName() + "." + index.getName() + "  dup key : {" + error + " }");
+          String err = "E11000 duplicate key error index: " + this.getFullName() + "." + index.getName() + "  dup key : {" + error + " }";
+          if (oldObject == null) {
+            // insert
+            throw fongoDb.duplicateKeyException(11000, err);
+          } else {
+            // update (MongoDB throws a different exception in case of an update, see issue #200)
+            throw fongoDb.mongoCommandException(11000, err);
+          }
         }
         return; // silently ignore.
       }

--- a/src/test/java/com/github/fakemongo/AbstractFongoV3Test.java
+++ b/src/test/java/com/github/fakemongo/AbstractFongoV3Test.java
@@ -5,6 +5,7 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.BulkWriteOperation;
 import com.mongodb.DBCollection;
 import com.mongodb.MongoBulkWriteException;
+import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.bulk.BulkWriteResult;
@@ -384,6 +385,19 @@ public abstract class AbstractFongoV3Test {
     // Then
     exception.expect(UnsupportedOperationException.class);
     deleteResult.getDeletedCount();
+  }
+
+  @Test
+  public void insertOneWithDuplicateValueForUniqueColumn_throwsMongoCommandException() {
+    // Given
+    MongoCollection collection = newCollection();
+    collection.createIndex(new Document("a", 1), new IndexOptions().name("a").unique(true));
+    collection.insertOne(new Document("_id", 1).append("a", 1));
+    collection.insertOne(new Document("_id", 2).append("a", 2));
+
+    // When
+    exception.expect(MongoCommandException.class);
+    collection.findOneAndUpdate(docId(2), new Document("$set", new Document("a", 1)));
   }
 
   @Test


### PR DESCRIPTION
Given the following data structure:
```json
{
  "_id": "someId",
  "value": "someValue"
}
```
There is a unique index on `value`.

If I try to update a document using `findAndModify` and set `value` to an already existing `value` in the collection, the following happens:

Fongo throws a `com.mongodb.DuplicateKeyException`.
MongoDB throws a `com.mongodb.MongoCommandException`.

MongoDB driver version: `3.2.0`
MongoDB version: `3.2.4`
Fongo version: `2.0.6`

Is there a way I can provide a PR? If so, please point me into a direction and I'll try my best :)