### PR TITLE
Allow $geoIntersect with MultiPoint geometries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,12 +154,6 @@
             <version>19.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.wololo</groupId>
-            <artifactId>jts2geojson</artifactId>
-            <version>0.7.0</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,12 @@
             <version>19.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wololo</groupId>
+            <artifactId>jts2geojson</artifactId>
+            <version>0.7.0</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/src/main/java/com/github/fakemongo/impl/geo/GeoUtil.java
+++ b/src/main/java/com/github/fakemongo/impl/geo/GeoUtil.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.geojson.GeoJsonObject;
 import org.geojson.LngLatAlt;
 import org.geojson.MultiPolygon;
+import org.geojson.MultiPoint;
 import org.geojson.Point;
 import org.geojson.Polygon;
 import org.slf4j.Logger;
@@ -188,6 +189,9 @@ public final class GeoUtil {
           if (object instanceof Point) {
             Point point = (Point) object;
             coordinate = new Coordinate(point.getCoordinates().getLatitude(), point.getCoordinates().getLongitude());
+          } else if (object instanceof MultiPoint) {
+            MultiPoint point = (MultiPoint) object;
+            coordinate = new Coordinate(point.getCoordinates().get(0).getLatitude(), point.getCoordinates().get(0).getLongitude());
           } else if (object instanceof Polygon) {
             Polygon point = (Polygon) object;
             coordinate = new Coordinate(point.getCoordinates().get(0).get(0).getLatitude(), point.getCoordinates().get(0).get(0).getLongitude());
@@ -249,6 +253,9 @@ public final class GeoUtil {
         if (geoJsonObject instanceof Point) {
           Point point = (Point) geoJsonObject;
           return createGeometryPoint(toCoordinate(point.getCoordinates()));
+        } else if (geoJsonObject instanceof MultiPoint) {
+          MultiPoint points = (MultiPoint) geoJsonObject;
+          return toJtsMultiPoint(points.getCoordinates());
         } else if (geoJsonObject instanceof Polygon) {
           Polygon polygon = (Polygon) geoJsonObject;
           return toJtsPolygon(polygon.getCoordinates());
@@ -269,6 +276,14 @@ public final class GeoUtil {
       throw new IllegalArgumentException("can't handle " + FongoJSON.serialize(dbObject));
     }
     return null;
+  }
+
+  private static Geometry toJtsMultiPoint(List<LngLatAlt> lngLatAlts) {
+    List<Coordinate> coordinates = new ArrayList<Coordinate>();
+    for (LngLatAlt lngLatAlt : lngLatAlts) {
+      coordinates.add(toCoordinate(lngLatAlt));
+    }
+    return GEOMETRY_FACTORY.createMultiPoint(coordinates.toArray(new Coordinate[0]));
   }
 
   public static com.vividsolutions.jts.geom.Polygon toJtsPolygon(List<List<LngLatAlt>> lngLatAlts) {

--- a/src/test/java/com/github/fakemongo/impl/geo/GeoUtilTest.java
+++ b/src/test/java/com/github/fakemongo/impl/geo/GeoUtilTest.java
@@ -1,0 +1,80 @@
+package com.github.fakemongo.impl.geo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.DBObject;
+import com.mongodb.util.JSON;
+import com.vividsolutions.jts.geom.Coordinate;
+import org.geojson.*;
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.util.Arrays.array;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThat;
+
+public class GeoUtilTest {
+
+  @Test
+  public void testGeoJsonPointsCanBeConvertedToJTSGeometry() throws Exception {
+    final Point geoJson = new Point(pos(-1, -1));
+    final DBObject dbObject = toDBObject(geoJson);
+
+    final com.vividsolutions.jts.geom.Geometry geometry = GeoUtil.toGeometry(dbObject);
+
+    assertThat(geometry, instanceOf(com.vividsolutions.jts.geom.Point.class));
+    assertArrayEquals(array(coord(-1, -1)), geometry.getCoordinates());
+  }
+
+  @Test
+  public void testGeoJsonMultiPointsCanBeConvertedToJTSGeometry() throws Exception {
+    final MultiPoint geoJson = new MultiPoint(pos(-1, -1), pos(1, 1));
+    final DBObject dbObject = toDBObject(geoJson);
+
+    final com.vividsolutions.jts.geom.Geometry geometry = GeoUtil.toGeometry(dbObject);
+
+    assertThat(geometry, instanceOf(com.vividsolutions.jts.geom.MultiPoint.class));
+    assertArrayEquals(array(coord(-1, -1), coord(1, 1)), geometry.getCoordinates());
+  }
+
+  @Test
+  public void testGeoJsonPolygonsCanBeConvertedToJTSGeometry() throws Exception {
+    final Polygon geoJson = new Polygon(createRing(pos(-1, -1), pos(1, -1), pos(0, 1), pos(-1, -1)));
+    final DBObject dbObject = toDBObject(geoJson);
+
+    final com.vividsolutions.jts.geom.Geometry geometry = GeoUtil.toGeometry(dbObject);
+
+    assertThat(geometry, instanceOf(com.vividsolutions.jts.geom.Polygon.class));
+    assertArrayEquals(array(coord(-1, -1), coord(-1, 1), coord(1, 0), coord(-1, -1)), geometry.getCoordinates());
+  }
+
+  @Test
+  public void testGeoJsonMultiPolygonsCanBeConvertedToJTSGeometry() throws Exception {
+    final MultiPolygon geoJson = new MultiPolygon(new Polygon(createRing(pos(-1, -1), pos(1, -1), pos(0, 1), pos(-1, -1))));
+    final DBObject dbObject = toDBObject(geoJson);
+
+    final com.vividsolutions.jts.geom.Geometry geometry = GeoUtil.toGeometry(dbObject);
+
+    assertThat(geometry, instanceOf(com.vividsolutions.jts.geom.MultiPolygon.class));
+    assertArrayEquals(array(coord(-1, -1), coord(-1, 1), coord(1, 0), coord(-1, -1)), geometry.getCoordinates());
+  }
+
+  private Coordinate coord(int x, int y) {
+    return new Coordinate(x, y);
+  }
+
+  private LngLatAlt pos(int longitude, int latitude) {
+    return new LngLatAlt(longitude, latitude);
+  }
+
+  private List<LngLatAlt> createRing(LngLatAlt... coordinates) {
+    return asList(coordinates);
+  }
+
+  private DBObject toDBObject(GeoJsonObject geoJsonGeometry) throws JsonProcessingException {
+    return (DBObject) JSON.parse(new ObjectMapper().writeValueAsString(geoJsonGeometry));
+  }
+}


### PR DESCRIPTION
Allows `$geoIntersect`queries to use GeoJSON MultiPoint geometries. This is supported by MongoDB and useful to find geometries that contain any point from a given set with a single query.