### PR TITLE
Fixed NullPointerException when calling cursor.length()

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCursor.java
+++ b/src/main/java/com/mongodb/FongoDBCursor.java
@@ -116,6 +116,7 @@ public class FongoDBCursor extends DBCursor {
 
   @Override
   public int length() {
+    fetch();
     return this.objects.size();
   }
 

--- a/src/test/java/com/github/fakemongo/FongoFindTest.java
+++ b/src/test/java/com/github/fakemongo/FongoFindTest.java
@@ -102,4 +102,12 @@ public class FongoFindTest {
         new BasicDBObject("lang", new BasicDBObject("$in", new HashSet<String>(newArrayList("de")))))
     ).isNotNull();
   }
+
+  @Test
+  public void testCursorLength() {
+    DBCollection collection = fongoRule.newCollection();
+    collection.insert(new BasicDBObject("_id", 1).append("lang", "de"));
+    assertThat(collection.find().length())
+            .isEqualTo(1);
+  }
 }


### PR DESCRIPTION
Data is fetched in the original implementation of length(), so it should be done here as well