### PR TITLE
add support for different DuplicateKeyException behavior between mong…

### DIFF
--- a/src/main/java/com/github/fakemongo/Fongo.java
+++ b/src/main/java/com/github/fakemongo/Fongo.java
@@ -47,6 +47,7 @@ public class Fongo implements OperationExecutor {
   private final static Logger LOG = LoggerFactory.getLogger(Fongo.class);
 
   public static final ServerVersion V3_2_SERVER_VERSION = new ServerVersion(3, 2);
+  public static final ServerVersion V3_3_SERVER_VERSION = new ServerVersion(3, 3);
   public static final ServerVersion V3_SERVER_VERSION = new ServerVersion(3, 0);
   public static final ServerVersion OLD_SERVER_VERSION = new ServerVersion(0, 0);
   public static final ServerVersion DEFAULT_SERVER_VERSION = V3_2_SERVER_VERSION;

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -1368,14 +1368,7 @@ public class FongoDBCollection extends DBCollection {
       if (!error.isEmpty()) {
         // TODO formatting : E11000 duplicate key error index: test.zip.$city_1_state_1_pop_1  dup key: { : "BARRE", : "MA", : 4546.0 }
         if (enforceDuplicates(concern)) {
-          String err = "E11000 duplicate key error index: " + this.getFullName() + "." + index.getName() + "  dup key : {" + error + " }";
-          if (oldObject == null) {
-            // insert
-            throw fongoDb.duplicateKeyException(11000, err);
-          } else {
-            // update (MongoDB throws a different exception in case of an update, see issue #200)
-            throw fongoDb.mongoCommandException(11000, err);
-          }
+          throw fongoDb.duplicateKeyException(11000, "E11000 duplicate key error index: " + this.getFullName() + "." + index.getName() + "  dup key : {" + error + " }", oldObject);
         }
         return; // silently ignore.
       }

--- a/src/test/java/com/github/fakemongo/AbstractFongoV3Test.java
+++ b/src/test/java/com/github/fakemongo/AbstractFongoV3Test.java
@@ -390,19 +390,6 @@ public abstract class AbstractFongoV3Test {
   }
 
   @Test
-  public void insertOneWithDuplicateValueForUniqueColumn_throwsMongoCommandException() {
-    // Given
-    MongoCollection collection = newCollection();
-    collection.createIndex(new Document("a", 1), new IndexOptions().name("a").unique(true));
-    collection.insertOne(new Document("_id", 1).append("a", 1));
-    collection.insertOne(new Document("_id", 2).append("a", 2));
-
-    // When
-    exception.expect(MongoCommandException.class);
-    collection.findOneAndUpdate(docId(2), new Document("$set", new Document("a", 1)));
-  }
-
-  @Test
   public void deleteMany_remove_many() {
     // Given
     MongoCollection collection = newCollection();
@@ -1186,7 +1173,7 @@ public abstract class AbstractFongoV3Test {
     Assertions.assertThat(collection.count()).isEqualTo(1);
   }
 
-  private Document docId(final Object value) {
+  protected static Document docId(final Object value) {
     return new Document("_id", value);
   }
 

--- a/src/test/java/com/github/fakemongo/FongoV3ServerVersion3_3Test.java
+++ b/src/test/java/com/github/fakemongo/FongoV3ServerVersion3_3Test.java
@@ -1,21 +1,21 @@
 package com.github.fakemongo;
 
-import com.mongodb.MongoCommandException;
+import com.mongodb.DuplicateKeyException;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.connection.ServerVersion;
 import org.bson.Document;
 import org.junit.Test;
 
-public class FongoV3ServerVersion3_2Test extends AbstractFongoV3Test {
+public class FongoV3ServerVersion3_3Test extends AbstractFongoV3Test {
 
   @Override
   public ServerVersion serverVersion() {
-    return Fongo.V3_2_SERVER_VERSION;
+    return Fongo.V3_3_SERVER_VERSION;
   }
 
     @Test
-    public void insertOneWithDuplicateValueForUniqueColumn_throwsMongoCommandException() {
+    public void insertOneWithDuplicateValueForUniqueColumn_throwsDuplicateKeyException() {
         // Given
         MongoCollection collection = newCollection();
         collection.createIndex(new Document("a", 1), new IndexOptions().name("a").unique(true));
@@ -23,7 +23,7 @@ public class FongoV3ServerVersion3_2Test extends AbstractFongoV3Test {
         collection.insertOne(new Document("_id", 2).append("a", 2));
 
         // When
-        exception.expect(MongoCommandException.class);
+        exception.expect(DuplicateKeyException.class);
         collection.findOneAndUpdate(docId(2), new Document("$set", new Document("a", 1)));
     }
 }


### PR DESCRIPTION
#200 was necessary to simulate behavior for mongo driver version < 3.3.0. With 3.3.0 upwards the behavior changed and a DuplicateKeyException is thrown.