### PR TITLE
validate documents to inserted into fongo (particularly keys containing dot)

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/aggregation/PipelineKeyword.java
+++ b/src/main/java/com/github/fakemongo/impl/aggregation/PipelineKeyword.java
@@ -5,7 +5,6 @@ import com.mongodb.DB;
 import com.mongodb.DBCollection;
 import com.mongodb.DBObject;
 import com.mongodb.FongoDB;
-
 import java.util.List;
 import java.util.UUID;
 
@@ -49,7 +48,7 @@ public abstract class PipelineKeyword {
   }
 
   protected DBCollection createAndInsert(List<DBObject> objects) {
-    DBCollection coll = fongo.doGetCollection(UUID.randomUUID().toString(), true);
+    DBCollection coll = fongo.doGetCollection(UUID.randomUUID().toString(), true, false);
     coll.insert(objects);
     return coll;
   }

--- a/src/main/java/com/mongodb/FongoDB.java
+++ b/src/main/java/com/mongodb/FongoDB.java
@@ -1,5 +1,12 @@
 package com.mongodb;
 
+import com.github.fakemongo.Fongo;
+import com.github.fakemongo.impl.Aggregator;
+import com.github.fakemongo.impl.ExpressionParser;
+import com.github.fakemongo.impl.geo.GeoUtil;
+import com.mongodb.connection.ServerVersion;
+import com.mongodb.util.JSON;
+import com.vividsolutions.jts.geom.Coordinate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -8,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonDouble;
@@ -16,14 +22,6 @@ import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.github.fakemongo.Fongo;
-import com.github.fakemongo.impl.Aggregator;
-import com.github.fakemongo.impl.ExpressionParser;
-import com.github.fakemongo.impl.geo.GeoUtil;
-import com.mongodb.connection.ServerVersion;
-import com.mongodb.util.JSON;
-import com.vividsolutions.jts.geom.Coordinate;
 
 /**
  * fongo override of com.mongodb.DB
@@ -86,16 +84,16 @@ public class FongoDB extends DB {
 
   @Override
   protected synchronized FongoDBCollection doGetCollection(String name) {
-    return doGetCollection(name, false);
+    return doGetCollection(name, false, true);
   }
 
   /**
    * Only for aggregation.
    */
-  public synchronized FongoDBCollection doGetCollection(String name, boolean idIsNotUniq) {
+  public synchronized FongoDBCollection doGetCollection(String name, boolean idIsNotUniq, boolean validateOnInsert) {
     FongoDBCollection coll = collMap.get(name);
     if (coll == null) {
-      coll = new FongoDBCollection(this, name, idIsNotUniq);
+      coll = new FongoDBCollection(this, name, idIsNotUniq, validateOnInsert);
       collMap.put(name, coll);
     }
     return coll;

--- a/src/test/java/com/github/fakemongo/FongoTest.java
+++ b/src/test/java/com/github/fakemongo/FongoTest.java
@@ -1,7 +1,6 @@
 package com.github.fakemongo;
 
 import ch.qos.logback.classic.Level;
-import static com.github.fakemongo.ExpectedMongoException.expectWriteConcernException;
 import com.github.fakemongo.impl.ExpressionParser;
 import com.github.fakemongo.impl.Util;
 import com.github.fakemongo.junit.FongoRule;
@@ -46,7 +45,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 import org.assertj.core.api.Assertions;
-import static org.assertj.core.api.Assertions.assertThat;
 import org.assertj.core.util.Lists;
 import org.bson.BSON;
 import org.bson.Document;
@@ -55,12 +53,6 @@ import org.bson.types.Binary;
 import org.bson.types.MaxKey;
 import org.bson.types.MinKey;
 import org.bson.types.ObjectId;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -68,6 +60,16 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.slf4j.LoggerFactory;
+
+
+import static com.github.fakemongo.ExpectedMongoException.expectWriteConcernException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class FongoTest {
 
@@ -160,7 +162,14 @@ public class FongoTest {
     assertEquals(2, collection.count(new BasicDBObject("n", 2)));
   }
 
-  @Test
+    @Test(expected = IllegalArgumentException.class)
+    public void should_not_allow_creating_docs_with_dot_in_key() {
+        DB db = fongoRule.getDB("db");
+        final DBCollection coll = db.createCollection("coll", null);
+        coll.insert(new BasicDBObject("a.b", 1));
+    }
+
+    @Test
   public void testCountOnCursor() {
     DBCollection collection = newCollection();
     collection.insert(new BasicDBObject("n", 1));


### PR DESCRIPTION
Following some production problem we've had because we thought a case was well-covered by UTs we noticed this lack of check shortcoming of fongo.

Once accepting this PR, fongo would validate objects as they're being inserted to collection, with exception applying to system indexes collection and Pipeline scenario where object validation should be different (if any) and is less important anyhow