### PR TITLE
compatibility with the mongo-scala-driver

### DIFF
--- a/src/main/java/com/github/fakemongo/async/FongoAsync.java
+++ b/src/main/java/com/github/fakemongo/async/FongoAsync.java
@@ -75,8 +75,8 @@ public class FongoAsync implements AsyncOperationExecutor {
   public FongoAsync(final String name, final ServerVersion serverVersion, final CodecRegistry codecRegistry) {
     this.name = name;
     this.serverAddress = new ServerAddress(new InetSocketAddress(ServerAddress.defaultHost(), ServerAddress.defaultPort()));
-    this.mongo = createMongo();
     this.fongo = new Fongo(name, serverVersion, codecRegistry);
+    this.mongo = createMongo();
   }
 
   /**

--- a/src/main/java/com/mongodb/async/client/MockAsyncMongoClient.java
+++ b/src/main/java/com/mongodb/async/client/MockAsyncMongoClient.java
@@ -17,7 +17,7 @@ public class MockAsyncMongoClient extends MongoClientImpl {
   public static MockAsyncMongoClient create(FongoAsync fongoAsync) {
     // using objenesis here to prevent default constructor from spinning up background threads.
 //    MockAsyncMongoClient client = new ObjenesisStd().getInstantiatorOf(MockAsyncMongoClient.class).newInstance();
-    MongoClientSettings settings = MongoClientSettings.builder().build();
+    MongoClientSettings settings = MongoClientSettings.builder().codecRegistry(fongoAsync.getFongo().getCodecRegistry()).build();
     MockAsyncMongoClient client = new MockAsyncMongoClient(fongoAsync, settings, new Cluster() {
       @Override
       public ClusterSettings getSettings() {


### PR DESCRIPTION
use the CodecRegistery from the Fongo instance when creating a MockAsyncMongoClient instance so thatFongoAsync is usable with the mongo-scala-driver