### PR TITLE
Fixed #311: added correct behavior of MongoCollection#insertMany in case option 'ordered' is set to false.

### DIFF
--- a/src/main/java/com/mongodb/FongoBulkWriteCombiner.java
+++ b/src/main/java/com/mongodb/FongoBulkWriteCombiner.java
@@ -1,0 +1,123 @@
+package com.mongodb;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+import org.bson.BsonDocument;
+import static java.util.Collections.*;
+
+public class FongoBulkWriteCombiner {
+
+  private final WriteConcern writeConcern;
+
+  private int insertedCount = 0;
+  private int matchedCount = 0;
+  private int removedCount = 0;
+  private int modifiedCount = 0;
+
+  private final Set<com.mongodb.BulkWriteUpsert> upserts = new TreeSet<com.mongodb.BulkWriteUpsert>(new Comparator<com.mongodb.BulkWriteUpsert>() {
+    @Override
+    public int compare(final com.mongodb.BulkWriteUpsert o1, final com.mongodb.BulkWriteUpsert o2) {
+      return (o1.getIndex() < o2.getIndex()) ? -1 : ((o1.getIndex() == o2.getIndex()) ? 0 : 1);
+    }
+  });
+  private final TreeSet<WriteError> errors = new TreeSet<WriteError>(new Comparator<WriteError>() {
+    @Override
+    public int compare(final WriteError o1, final WriteError o2) {
+      return (o1.getIndex() < o2.getIndex()) ? -1 : ((o1.getIndex() == o2.getIndex()) ? 0 : 1);
+    }
+  });
+
+  public FongoBulkWriteCombiner(WriteConcern writeConcern) {
+    this.writeConcern = writeConcern;
+  }
+
+  public void addReplaceResult(int idx, WriteResult wr) {
+    matchedCount += wr.getN();
+    modifiedCount += wr.getN();
+    if (!wr.isUpdateOfExisting()) {
+      if (wr.getUpsertedId() != null) {
+        upserts.add(new BulkWriteUpsert(idx, wr.getUpsertedId()));
+      }
+    }
+  }
+
+  public void addUpdateResult(int idx, WriteResult wr) {
+    if (wr.isUpdateOfExisting()) {
+      matchedCount += wr.getN();
+      modifiedCount += wr.getN();
+    } else {
+      if (wr.getUpsertedId() != null) {
+        upserts.add(new BulkWriteUpsert(idx, wr.getUpsertedId()));
+//            insertedCount++;
+      }
+    }
+  }
+
+  public void addRemoveResult(WriteResult wr) {
+    matchedCount += wr.getN();
+    removedCount += wr.getN();
+  }
+
+  public void addInsertResult(WriteResult wr) {
+    insertedCount += wr.getN();
+  }
+
+  public void addInsertError(int idx, WriteConcernException exception) {
+    errors.add(new WriteError(idx, exception));
+  }
+
+  public BulkWriteResult getBulkWriteResult(WriteConcern writeConcern) {
+    if (!writeConcern.isAcknowledged()) {
+      return new UnacknowledgedBulkWriteResult();
+    }
+    return new AcknowledgedBulkWriteResult(insertedCount, matchedCount, removedCount, modifiedCount, new ArrayList<BulkWriteUpsert>(upserts));
+  }
+
+  public void throwOnError() {
+    if (!errors.isEmpty()) {
+      BulkWriteResult bulkWriteResult = getBulkWriteResult(writeConcern);
+      throw new InsertManyWriteConcernException(bulkWriteResult, unmodifiableList(new ArrayList<WriteError>(errors)));
+    }
+  }
+
+  public static class WriteError {
+
+    private final int index;
+    private final int code;
+    private final String message;
+    private final BsonDocument details;
+    private final WriteConcernException exception;
+
+    public WriteError(int index, WriteConcernException exception) {
+      this.index = index;
+      this.exception = exception;
+      this.code = exception.getErrorCode();
+      this.message = exception.getErrorMessage();
+      this.details = exception.getResponse();
+    }
+
+    public int getIndex() {
+      return index;
+    }
+
+    public int getCode() {
+      return code;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
+    public BsonDocument getDetails() {
+      return details;
+    }
+
+    public WriteConcernException getException() {
+      return exception;
+    }
+
+  }
+
+}

--- a/src/main/java/com/mongodb/InsertManyWriteConcernException.java
+++ b/src/main/java/com/mongodb/InsertManyWriteConcernException.java
@@ -1,23 +1,24 @@
 package com.mongodb;
 
-public class InsertManyWriteConcernException extends WriteConcernException {
+import java.util.List;
+import static java.util.Collections.emptyList;
 
-  private BulkWriteResult bulkWriteResult;
-  private int erroneousIndex;
+public class InsertManyWriteConcernException extends RuntimeException {
 
-  public InsertManyWriteConcernException(BulkWriteResult bulkWriteResult, int erroneousIndex, WriteConcernException e) {
-    super(e.getResponse(), e.getServerAddress(), e.getWriteConcernResult());
+  private BulkWriteResult result;
+  private List<FongoBulkWriteCombiner.WriteError> errors = emptyList();
 
-    this.bulkWriteResult = bulkWriteResult;
-    this.erroneousIndex = erroneousIndex;
+  public InsertManyWriteConcernException(BulkWriteResult result, List<FongoBulkWriteCombiner.WriteError> errors) {
+    this.result = result;
+    this.errors = errors;
   }
 
-  public BulkWriteResult getBulkWriteResult() {
-    return bulkWriteResult;
+  public BulkWriteResult getResult() {
+    return result;
   }
 
-  public int getErroneousIndex() {
-    return erroneousIndex;
+  public List<FongoBulkWriteCombiner.WriteError> getErrors() {
+    return errors;
   }
 
 }

--- a/src/test/java/com/github/fakemongo/FongoInsertManyTest.java
+++ b/src/test/java/com/github/fakemongo/FongoInsertManyTest.java
@@ -11,9 +11,21 @@ import com.github.fakemongo.junit.FongoRule;
 import com.mongodb.MongoBulkWriteException;
 import com.mongodb.bulk.BulkWriteError;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.InsertManyOptions;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
+/**
+ * Behavior of real mongo driver's {@link com.mongodb.client.MongoCollection#insertMany} is as follows:
+ * <p>
+ * The first document of _id: 1 will insert successfully, but the second with the same _id insert will fail.
+ * This will also stop additional documents left in the queue from being inserted.
+ * <p>
+ * With ordered set to false, the insert operation would continue with any remaining documents.
+ *
+ * @see <a href="https://docs.mongodb.com/manual/reference/method/db.collection.insertMany/">db.collection.insertMany() &mdash; MongoDB Manual 3.4</a>
+ */
 public class FongoInsertManyTest {
 
   public static final boolean REAL_MONGO = false;
@@ -45,6 +57,86 @@ public class FongoInsertManyTest {
   }
 
   @Test
+  public void should_throw_MongoBulkWriteException_if_middle_document_is_duplicated_and_ordered() {
+    // Given
+    MongoCollection<Document> collection = fongoRule.getDatabase("db").getCollection("collection");
+    Document document1 = new Document("_id", 1);
+    Document document2 = new Document("_id", 2);
+    Document document2Duplicate = new Document("_id", 2);
+    Document document3 = new Document("_id", 3);
+
+    InsertManyOptions options = new InsertManyOptions().ordered(true);
+
+    // When/Then
+    try {
+      collection.insertMany(asList(document1, document2, document2Duplicate, document3), options);
+      fail("expected exception was not thrown");
+    } catch (MongoBulkWriteException ex) {
+      assertThat(ex.getWriteErrors()).containsExactly(
+          new BulkWriteError(11000, getDuplicateKeyMessage(2), new BsonDocument(), 2)
+      );
+      assertThat(ex.getWriteResult().getInsertedCount()).isEqualTo(2);
+    }
+    final List<Document> documents = collection.find().into(new ArrayList<Document>());
+
+    assertThat(documents).containsExactly(document1, document2);
+  }
+
+  @Test
+  public void should_throw_MongoBulkWriteException_if_middle_document_is_duplicated_and_unordered() {
+    // Given
+    MongoCollection<Document> collection = fongoRule.getDatabase("db").getCollection("collection");
+    Document document1 = new Document("_id", 1);
+    Document document2 = new Document("_id", 2);
+    Document document2Duplicate = new Document("_id", 2);
+    Document document3 = new Document("_id", 3);
+
+    InsertManyOptions options = new InsertManyOptions().ordered(false);
+
+    // When/Then
+    try {
+      collection.insertMany(asList(document1, document2, document2Duplicate, document3), options);
+      fail("expected exception was not thrown");
+    } catch (MongoBulkWriteException ex) {
+      assertThat(ex.getWriteErrors()).containsExactly(
+          new BulkWriteError(11000, getDuplicateKeyMessage(2), new BsonDocument(), 2)
+      );
+      assertThat(ex.getWriteResult().getInsertedCount()).isEqualTo(3);
+    }
+    final List<Document> documents = collection.find().into(new ArrayList<Document>());
+
+    assertThat(documents).containsExactly(document1, document2, document3);
+  }
+
+  @Test
+  public void should_throw_MongoBulkWriteException_if_multiple_duplicates_and_unordered() {
+    // Given
+    MongoCollection<Document> collection = fongoRule.getDatabase("db").getCollection("collection");
+    Document document1 = new Document("_id", 1);
+    Document document1Duplicate = new Document("_id", 1);
+    Document document2 = new Document("_id", 2);
+    Document document2Duplicate = new Document("_id", 2);
+    Document document3 = new Document("_id", 3);
+
+    InsertManyOptions options = new InsertManyOptions().ordered(false);
+
+    // When/Then
+    try {
+      collection.insertMany(asList(document1, document1Duplicate, document2, document2Duplicate, document3), options);
+      fail("expected exception was not thrown");
+    } catch (MongoBulkWriteException ex) {
+      assertThat(ex.getWriteErrors()).containsExactly(
+          new BulkWriteError(11000, getDuplicateKeyMessage(1), new BsonDocument(), 1),
+          new BulkWriteError(11000, getDuplicateKeyMessage(2), new BsonDocument(), 3)
+      );
+      assertThat(ex.getWriteResult().getInsertedCount()).isEqualTo(3);
+    }
+    final List<Document> documents = collection.find().into(new ArrayList<Document>());
+
+    assertThat(documents).containsExactly(document1, document2, document3);
+  }
+
+  @Test
   public void should_throw_MongoBulkWriteException_on_first_insert_and_abort_consequent_inserts() {
     // Given
     MongoCollection<Document> collection = fongoRule.getDatabase("db").getCollection("collection");
@@ -56,6 +148,7 @@ public class FongoInsertManyTest {
     // When/Then
     try {
       collection.insertMany(asList(document1, document2, document3));
+      fail("expected exception was not thrown");
     } catch (MongoBulkWriteException ex) {
       // then
       assertThat(ex.getWriteErrors()).containsExactly(
@@ -80,6 +173,7 @@ public class FongoInsertManyTest {
     // When/Then
     try {
       collection.insertMany(asList(document1, document2, document3));
+      fail("expected exception was not thrown");
     } catch (MongoBulkWriteException ex) {
       // then
       assertThat(ex.getWriteErrors()).containsExactly(
@@ -90,6 +184,54 @@ public class FongoInsertManyTest {
     final List<Document> documents = collection.find().into(new ArrayList<Document>());
 
     assertThat(documents).containsExactly(document3, document1, document2);
+  }
+
+  @Test
+  public void should_throw_MongoBulkWriteException_for_first_insert_and_complete_consequent_inserts_if_unordered() {
+    // Given
+    MongoCollection<Document> collection = fongoRule.getDatabase("db").getCollection("collection");
+    Document document1 = new Document("_id", 1);
+    Document document2 = new Document("_id", 2);
+    Document document3 = new Document("_id", 3);
+    collection.insertOne(document1);
+
+    // When/Then
+    try {
+      collection.insertMany(asList(document1, document2, document3), new InsertManyOptions().ordered(false));
+      fail("expected exception was not thrown");
+    } catch (MongoBulkWriteException ex) {
+      assertThat(ex.getWriteErrors()).containsExactly(
+          new BulkWriteError(11000, getDuplicateKeyMessage(1), new BsonDocument(), 0)
+      );
+      assertThat(ex.getWriteResult().getInsertedCount()).isEqualTo(2);
+    }
+    final List<Document> documents = collection.find().into(new ArrayList<Document>());
+
+    assertThat(documents).containsExactly(document1, document2, document3);
+  }
+
+  @Test
+  public void should_throw_MongoBulkWriteException_for_middle_insert_and_complete_other_inserts_if_unordered() {
+    // Given
+    MongoCollection<Document> collection = fongoRule.getDatabase("db").getCollection("collection");
+    Document document1 = new Document("_id", 1);
+    Document document2 = new Document("_id", 2);
+    Document document3 = new Document("_id", 3);
+    collection.insertOne(document2);
+
+    // When/Then
+    try {
+      collection.insertMany(asList(document1, document2, document3), new InsertManyOptions().ordered(false));
+      fail("expected exception was not thrown");
+    } catch (MongoBulkWriteException ex) {
+      assertThat(ex.getWriteErrors()).containsExactly(
+          new BulkWriteError(11000, getDuplicateKeyMessage(2), new BsonDocument(), 1)
+      );
+      assertThat(ex.getWriteResult().getInsertedCount()).isEqualTo(2);
+    }
+    final List<Document> documents = collection.find().into(new ArrayList<Document>());
+
+    assertThat(documents).containsExactly(document2, document1, document3);
   }
 
   private String getDuplicateKeyMessage(Object value) {


### PR DESCRIPTION
I have a concern regarding usage of `IndexMap`. It seems that it is not quite correct how it is used in the current implementation. However, looks like it does not do any harm as for now.

Corresponding tests are included.