### PR TITLE
Fixed that .distinct() doesn't decode values

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -1513,6 +1513,17 @@ public class FongoDBCollection extends DBCollection {
     return list;
   }
 
+  public static BsonArray bsonArray(List<?> list) {
+    if (list == null) {
+      return null;
+    }
+
+    final BasicDBList dbList = new BasicDBList();
+    dbList.addAll(list);
+
+    return bsonDocument(new BasicDBObject("array", dbList)).getArray("array");
+  }
+
   public static BsonDocument bsonDocument(DBObject dbObject) {
     if (dbObject == null) {
       return null;


### PR DESCRIPTION
This makes sure that `.distinct(…, SomeType.class)` properly uses the decoder for `SomeType`.

Added [a test](https://github.com/fakemongo/fongo/pull/313/files#diff-b57de7c310971c42f648a752d9d1fa7eR608) for it.