### PR TITLE
Fixed bugs in bulk and replace result document

### DIFF
--- a/src/main/java/com/github/fakemongo/FongoConnection.java
+++ b/src/main/java/com/github/fakemongo/FongoConnection.java
@@ -357,7 +357,7 @@ public class FongoConnection implements Connection {
       indexMap = indexMap.add(0, offset);
       BulkWriteResult bwr = bulkWriteResult(bulkWriteResult);
       int upsertCount = bwr.getUpserts().size();
-      offset += upsertCount;
+      offset += Math.max(upsertCount, 1);
       bulkWriteBatchCombiner.addResult(bwr, indexMap);
       idx++;
     }

--- a/src/main/java/com/mongodb/FongoBulkWriteCombiner.java
+++ b/src/main/java/com/mongodb/FongoBulkWriteCombiner.java
@@ -34,13 +34,8 @@ public class FongoBulkWriteCombiner {
   }
 
   public void addReplaceResult(int idx, WriteResult wr) {
-    matchedCount += wr.getN();
-    modifiedCount += wr.getN();
-    if (!wr.isUpdateOfExisting()) {
-      if (wr.getUpsertedId() != null) {
-        upserts.add(new BulkWriteUpsert(idx, wr.getUpsertedId()));
-      }
-    }
+    // Same logic applies
+    addUpdateResult(idx, wr);
   }
 
   public void addUpdateResult(int idx, WriteResult wr) {

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -298,9 +298,10 @@ public class FongoDBCollection extends DBCollection {
         o.put(ID_FIELD_NAME, Util.clone(o.get(ID_FIELD_NAME)));
       }
       @SuppressWarnings("unchecked") Iterator<DBObject> oldObjects = _idIndex.retrieveObjects(q).iterator();
-      if (oldObjects.hasNext() || upsert) {
+      if (oldObjects.hasNext()) {
         addToIndexes(Util.clone(o), oldObjects.hasNext() ? oldObjects.next() : null, concern);
         updatedDocuments++;
+        updatedExisting = true;
       }
     } else {
       Filter filter = buildFilter(q);
@@ -319,14 +320,14 @@ public class FongoDBCollection extends DBCollection {
           }
         }
       }
-      if (updatedDocuments == 0 && upsert) {
-        BasicDBObject newObject = createUpsertObject(q);
-        fInsert(updateEngine.doUpdate(newObject, o, q, true), concern);
+    }
+    if (updatedDocuments == 0 && upsert) {
+      BasicDBObject newObject = createUpsertObject(q);
+      fInsert(updateEngine.doUpdate(newObject, o, q, true), concern);
 
-        updatedDocuments++;
-        updatedExisting = false;
-        upsertedId = newObject.get(ID_FIELD_NAME);
-      }
+      updatedDocuments++;
+      updatedExisting = false;
+      upsertedId = newObject.get(ID_FIELD_NAME);
     }
     return updateResult(updatedDocuments, updatedExisting, upsertedId);
   }


### PR DESCRIPTION
1) In bulk write, the indexes of upserts in the result were incorrect
2) matched and modifiedCount in replace operation was also incorrect