### PR TITLE
Performing a $rename update should be a noop if the field being rename does not exist

### DIFF
--- a/src/main/java/com/github/fakemongo/impl/UpdateEngine.java
+++ b/src/main/java/com/github/fakemongo/impl/UpdateEngine.java
@@ -253,6 +253,7 @@ public class UpdateEngine {
       new BasicUpdate("$rename", true) {
         @Override
         void mergeAction(String subKey, DBObject subObject, Object object, DBObject objOriginal, boolean isCreated) {
+          if(!subObject.containsField(subKey)) return;
           Object objValue = subObject.removeField(subKey);
           String newKey = (String) object;
           Util.putValue(objOriginal, newKey, objValue);

--- a/src/test/java/com/github/fakemongo/FongoTest.java
+++ b/src/test/java/com/github/fakemongo/FongoTest.java
@@ -968,6 +968,17 @@ public class FongoTest {
   }
 
   @Test
+  public void testRenameOnFieldThatDoesNotExistDoesNothing() {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", 1).append("a", "value"));
+    collection.update(new BasicDBObject("_id", 1), new BasicDBObject("$rename", new BasicDBObject("b", "a")));
+    List<DBObject> results = collection.find().toArray();
+    assertEquals(Arrays.asList(
+            new BasicDBObject("_id", 1).append("a", "value")
+    ), results);
+  }
+
+  @Test
   public void testCompoundDateIdUpserts() {
     DBCollection collection = newCollection();
     DBObject query = new BasicDBObjectBuilder().push("_id")


### PR DESCRIPTION
I ran into an issue where performing a $rename did not work as expected. If I run $rename once, it will correctly rename the field. If I run the same $rename again it will try to rename the non-existent field over the new field, and null it out. Reading the mongo docs, if you try to rename a field that does not exist, it should be a noop. 

I made the required change, and added a test to cover. Happy to take comments if I have missed something.