### PR TITLE
Fixed async insert/delete not working with 3.6 driver

### DIFF
--- a/src/main/java/com/github/fakemongo/FongoConnection.java
+++ b/src/main/java/com/github/fakemongo/FongoConnection.java
@@ -610,7 +610,21 @@ public class FongoConnection implements Connection {
       }
     } else if (command.containsKey("delete")) {
       final FongoDBCollection dbCollection = (FongoDBCollection) db.getCollection(command.get("delete").asString().getValue());
-      List<BsonValue> documentsToDelete = command.getArray("deletes").getValues();
+      List<BsonValue> documentsToDelete;
+
+      if (payload != null) {
+        if (payload.hasAnotherSplit()) {
+          documentsToDelete = Collections.singletonList(payload.getPayload().get(payload.getPosition()));
+          payload.setPosition(payload.getPosition() + 1);
+        }
+        else {
+          documentsToDelete = Collections.emptyList();
+        }
+      }
+      else {
+        documentsToDelete = command.getArray("deletes").getValues();
+      }
+
       for (BsonValue document : documentsToDelete) {
         if (!document.asDocument().containsKey("limit")) {
           throw new MongoCommandException(new BsonDocument("ok", BsonBoolean.FALSE).append("code", new BsonInt32(9)), this.fongo.getServerAddress());
@@ -641,7 +655,13 @@ public class FongoConnection implements Connection {
           numDocsDeleted += result.getN();
         }
       }
-      return (T) new Document("ok", 1).append("n", numDocsDeleted);
+
+      if (payload != null) {
+        return (T) new BsonDocument("ok", new BsonInt32(1)).append("n", new BsonInt32(numDocsDeleted));
+      }
+      else {
+        return (T) new Document("ok", 1).append("n", numDocsDeleted);
+      }
     } else if (command.containsKey("find")) {
       final FongoDBCollection dbCollection = (FongoDBCollection) db.getCollection(command.get("find").asString().getValue());
       BsonInt32 limit = getValue(command, "limit", -1);

--- a/src/test/java/com/github/fakemongo/FongoAsyncTest.java
+++ b/src/test/java/com/github/fakemongo/FongoAsyncTest.java
@@ -54,13 +54,19 @@ public class FongoAsyncTest {
   public void insertOne_and_count_works() throws Throwable {
     // Given
     final MongoCollection<Document> collection = newCollection();
-    collection.insertOne(new Document("i", 1), null);
-    collection.insertOne(new Document("i", 1), null);
+
+    AwaitResultSingleResultCallback<Void> result1 = new AwaitResultSingleResultCallback<Void>();
+    collection.insertOne(new Document("i", 1), result1);
+    result1.awaitResult();
+
+    AwaitResultSingleResultCallback<Void> result2 = new AwaitResultSingleResultCallback<Void>();
+    collection.insertOne(new Document("i", 1), result2);
+    result2.awaitResult();
 
     // When/Then
-    AwaitResultSingleResultCallback<Long> result = new AwaitResultSingleResultCallback<Long>();
-    collection.count(result);
-    assertThat(result.awaitResult()).isEqualTo(2L);
+    AwaitResultSingleResultCallback<Long> result3 = new AwaitResultSingleResultCallback<Long>();
+    collection.count(result3);
+    assertThat(result3.awaitResult()).isEqualTo(2L);
   }
 
   @Test


### PR DESCRIPTION
- Fixed that `FongoAsyncTest` didn't fail for unexpected exceptions in `insertOne`.
- Fixed `DuplicateKeyException` when inserting documents using `FongoAsync` caused by an endless loop due to wrong use of `SplittablePayload`.
- Enabled `deleteMany_remove_many` test for `FongoAsync`.
- Made `FongoConnection` handle delete commands with payload.