### PR TITLE
BulkWriteOperation.execute() now throws BulkWriteException

### DIFF
--- a/src/main/java/com/mongodb/FongoBulkWriteCombiner.java
+++ b/src/main/java/com/mongodb/FongoBulkWriteCombiner.java
@@ -2,10 +2,10 @@ package com.mongodb;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import org.bson.BsonDocument;
-import static java.util.Collections.*;
 
 public class FongoBulkWriteCombiner {
 
@@ -70,10 +70,14 @@ public class FongoBulkWriteCombiner {
     return new AcknowledgedBulkWriteResult(insertedCount, matchedCount, removedCount, modifiedCount, new ArrayList<BulkWriteUpsert>(upserts));
   }
 
-  public void throwOnError() {
+  public void throwOnError(ServerAddress address) {
     if (!errors.isEmpty()) {
+      List<BulkWriteError> bwErrors = new ArrayList<BulkWriteError>();
+      for (WriteError e: errors) {
+        bwErrors.add(new BulkWriteError(e.code, e.message, FongoDBCollection.dbObject(e.details), e.index));
+      }
       BulkWriteResult bulkWriteResult = getBulkWriteResult(writeConcern);
-      throw new InsertManyWriteConcernException(bulkWriteResult, unmodifiableList(new ArrayList<WriteError>(errors)));
+      throw new BulkWriteException(bulkWriteResult, bwErrors, null, address);
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/fakemongo/fongo/issues/328

tl;dr: In mongo-java-driver 3.4.2 (and higher), calling `BulkWriteOperation.execute()` throws a `BulkWriteException` when some of the writes fail. fongo was throwing `DuplicateKeyException` for the same operation. This PR brings fongo in line with that behavior. 

I left a comment in [translateWriteErrorsToNew](https://github.com/fakemongo/fongo/pull/334/files#diff-754e00c5766f1acd0423113c799a39f4R1612): the tests in `FongoInsertManyTest`, such as `should_throw_MongoBulkWriteException_if_middle_document_is_duplicated_and_ordered`, [specifically check for an _empty_ document in the `details` field](https://github.com/fakemongo/fongo/blob/master/src/test/java/com/github/fakemongo/FongoInsertManyTest.java#L75) of the `BulkWriteError`. 

This feels weird to me because it means I have to throw away data when I translate a `com.mongodb.BulkWriteError` to a `com.mongodb.bulk.BulkWriteError`, but it's what the unit tests are looking for and I'm assuming those unit tests are validating how mongo behaves, so I maintained that behavior instead of modifying the test. 